### PR TITLE
Implement JSON configuration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Project Overview
 
-A GUI-based web scraper application for Windows systems built with Python. The application enables users to configure, schedule, and manage web scraping tasks through an intuitive interface.
+A GUI-based web scraper application for Windows systems built with Python. The application enables users to configure, schedule, and manage web scraping tasks through an intuitive interface. Configuration files are stored in JSON format.
 
 ## Installation
 
@@ -14,6 +14,28 @@ A GUI-based web scraper application for Windows systems built with Python. The a
 
 ```bash
 pip install -r requirements.txt
+```
+
+## Configuration Helpers
+
+The `config_manager` module offers two helper functions:
+
+- `load_config(path)` – Load a configuration from a file. If the file does not exist or contains invalid JSON, a default configuration is returned.
+- `save_config(data, path)` – Save a configuration dictionary to the specified path.
+
+Example usage:
+
+```python
+from src.utils.config_manager import load_config, save_config
+
+# Load configuration or get defaults
+config = load_config("data/config.json")
+
+# Modify configuration as needed
+config["settings"]["debug"] = True
+
+# Save the updated configuration
+save_success = save_config(config, "data/config.json")
 ```
 
 ## Usage

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -1,0 +1,43 @@
+import json
+import os
+from typing import Any, Dict
+
+# Default configuration used when loading fails or no file is found
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "websites": [],
+    "settings": {}
+}
+
+def load_config(path: str) -> Dict[str, Any]:
+    """Load configuration from ``path`` in JSON format.
+
+    If the file does not exist or contains invalid JSON, ``DEFAULT_CONFIG`` is
+    returned instead.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        # Return a copy of the default configuration if the file is missing
+        return DEFAULT_CONFIG.copy()
+    except json.JSONDecodeError:
+        # Invalid JSON content; ignore the file and return defaults
+        return DEFAULT_CONFIG.copy()
+    except OSError:
+        # Any other file-related error also results in default config
+        return DEFAULT_CONFIG.copy()
+
+def save_config(data: Dict[str, Any], path: str) -> bool:
+    """Save ``data`` as JSON to ``path``.
+
+    The directory is created if it does not exist. Returns ``True`` if the
+    configuration was saved successfully, otherwise ``False``.
+    """
+    try:
+        os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fp:
+            json.dump(data, fp, indent=4)
+        return True
+    except OSError:
+        return False
+


### PR DESCRIPTION
## Summary
- add a `config_manager` module with `load_config` and `save_config`
- document configuration helpers and example usage in README

## Testing
- `python -m py_compile src/utils/config_manager.py`
- ran a short Python snippet to exercise `load_config` and `save_config`


------
https://chatgpt.com/codex/tasks/task_e_686d4522dfa48332b6858649f5fd8408