### PR TITLE
Annotate task scheduler functions

### DIFF
--- a/src/scheduling/task_scheduler.py
+++ b/src/scheduling/task_scheduler.py
@@ -1,14 +1,28 @@
+from typing import Any, Callable, Dict, List, Tuple
+
+
 class TaskScheduler:
     """Simple in-memory task scheduler."""
 
-    def __init__(self):
-        self.tasks = []
+    def __init__(self) -> None:
+        """Initialize the scheduler."""
+        self.tasks: List[
+            Tuple[Callable[..., Any], Tuple[Any, ...], Dict[str, Any]]
+        ] = []
 
-    def add_task(self, func, *args, **kwargs):
-        """Add a task callable with arguments."""
+    def add_task(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> None:
+        """Add a task callable with arguments.
+
+        Args:
+            func: The callable to execute.
+            *args: Positional arguments for ``func``.
+            **kwargs: Keyword arguments for ``func``.
+        """
         self.tasks.append((func, args, kwargs))
 
-    def run_all(self):
+    def run_all(self) -> None:
         """Run all scheduled tasks in the order they were added."""
         for func, args, kwargs in list(self.tasks):
             func(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add typing imports
- annotate `__init__`, `add_task`, and `run_all`
- add Google style docstrings to match project guidelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d5e49e1408332b14422158820c2da