### PR TITLE
Add brief module docstrings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Command-line entry point for running scheduled jobs."""
+
 import time
 
 from src.scheduling.schedule_manager import ScheduleManager

--- a/src/scheduling/schedule_manager.py
+++ b/src/scheduling/schedule_manager.py
@@ -1,3 +1,5 @@
+"""High-level interface for managing recurring tasks."""
+
 import schedule
 from typing import Callable, Dict
 

--- a/src/scheduling/task_scheduler.py
+++ b/src/scheduling/task_scheduler.py
@@ -1,3 +1,5 @@
+"""Provides a basic scheduler for executing queued callables."""
+
 class TaskScheduler:
     """Simple in-memory task scheduler."""
 

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -1,3 +1,5 @@
+"""Utility functions for reading and writing configuration files."""
+
 import json
 import os
 from typing import Any, Dict


### PR DESCRIPTION
This PR has been superseded by #14 which resolves the merge conflicts.

The conflicts arose because PR #10 modified the same files (particularly `src/scheduling/task_scheduler.py`) that this PR wanted to add module docstrings to. PR #14 contains the same changes but incorporates the type annotations and docstrings from PR #10.

Closed in favor of: #14