### PR TITLE
Add malformed JSON config test

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -15,3 +15,11 @@ def test_load_missing(tmp_path):
     path = tmp_path / "missing.json"
     loaded = config_manager.load_config(str(path))
     assert loaded == {"websites": [], "settings": {}}
+
+
+def test_load_malformed(tmp_path):
+    """Load a file containing malformed JSON and ensure defaults are returned."""
+    path = tmp_path / "malformed.json"
+    path.write_text("{ invalid json [")
+    loaded = config_manager.load_config(str(path))
+    assert loaded == config_manager.DEFAULT_CONFIG


### PR DESCRIPTION
## Summary
- extend config manager tests with malformed JSON case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5e4af0b88332919d4fe7bc320b7c