### PR TITLE
Add module docstrings (resolved conflicts)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Command-line entry point for running scheduled jobs."""
+
 import time
 
 from src.scheduling.schedule_manager import ScheduleManager

--- a/src/scheduling/schedule_manager.py
+++ b/src/scheduling/schedule_manager.py
@@ -1,3 +1,5 @@
+"""High-level interface for managing recurring tasks."""
+
 import schedule
 from typing import Callable, Dict
 

--- a/src/scheduling/task_scheduler.py
+++ b/src/scheduling/task_scheduler.py
@@ -1,3 +1,5 @@
+"""Provides a basic scheduler for executing queued callables."""
+
 from typing import Any, Callable, Dict, List, Tuple
 
 

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -1,3 +1,5 @@
+"""Utility functions for reading and writing configuration files."""
+
 import json
 import os
 from typing import Any, Dict


### PR DESCRIPTION
## Summary
- document utilities for config management
- document simple task scheduler module
- document schedule manager module
- document main entry point

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

## Conflict Resolution
This PR resolves the merge conflicts in PR #11 by incorporating the changes from PR #10 (type annotations and docstrings) while adding the missing module docstrings.

**Changes made:**
- Added module docstring to `main.py`
- Added module docstring to `src/scheduling/schedule_manager.py`
- Added module docstring to `src/scheduling/task_scheduler.py` (resolved conflict with PR #10)
- Added module docstring to `src/utils/config_manager.py`

Replaces: #11