### PR TITLE
Add .gitignore for Python build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Python virtual environments
+venv/
+ENV/
+env/
+.venv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+
+# Log files
+*.log
+logs/
+data/logs/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+coverage.xml
+
+# mypy
+.mypy_cache/
+
+# Sphinx documentation
+/docs/_build/
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+


### PR DESCRIPTION
## Summary
- add a Python-focused `.gitignore` to exclude virtualenvs, bytecode and logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7a06c61c8332ad7d2dcdcd5517a6