### PR TITLE
Add tests for scraper engine and GUI modules

### DIFF
--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1,0 +1,8 @@
+from src.scraping.content_extractor import ContentExtractor
+
+
+def test_extract_returns_none():
+    extractor = ContentExtractor()
+    html = "<html><body><p>Hello</p></body></html>"
+    result = extractor.extract(html)
+    assert result is None

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,30 @@
+from src.gui.main_window import MainWindow
+from src.gui.website_manager import WebsiteManager
+from src.gui.scheduler_dialog import SchedulerDialog
+from src.gui.settings_panel import SettingsPanel
+
+
+def test_main_window_show():
+    window = MainWindow()
+    result = window.show()
+    assert result is None
+
+
+def test_website_manager_methods():
+    manager = WebsiteManager()
+    add_result = manager.add_website("http://example.com")
+    remove_result = manager.remove_website("http://example.com")
+    assert add_result is None
+    assert remove_result is None
+
+
+def test_scheduler_dialog_open():
+    dialog = SchedulerDialog()
+    result = dialog.open()
+    assert result is None
+
+
+def test_settings_panel_open():
+    panel = SettingsPanel()
+    result = panel.open()
+    assert result is None

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1,0 +1,9 @@
+from src.scraping.output_manager import OutputManager
+
+
+def test_save_returns_none(tmp_path):
+    manager = OutputManager()
+    data = {"hello": "world"}
+    path = tmp_path / "output.txt"
+    result = manager.save(data, str(path))
+    assert result is None

--- a/tests/test_scraper_engine.py
+++ b/tests/test_scraper_engine.py
@@ -1,0 +1,7 @@
+from src.scraping.scraper_engine import ScraperEngine
+
+
+def test_scrape_returns_none():
+    engine = ScraperEngine()
+    result = engine.scrape("http://example.com")
+    assert result is None


### PR DESCRIPTION
## Summary
- add tests for scraper engine
- add tests for content extractor
- add tests for output manager
- add tests for GUI components (main window, website manager, scheduler dialog, settings panel)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d79eb67dc8332b2e622eede478113