### PR TITLE
Persist scheduler tasks to SQLite

### DIFF
--- a/src/scheduling/schedule_manager.py
+++ b/src/scheduling/schedule_manager.py
@@ -1,19 +1,29 @@
-"""High-level interface for managing recurring tasks."""
+"""High-level interface for managing recurring tasks with persistence."""
+
+import importlib
+import os
+import sqlite3
+from typing import Callable, Dict
 
 import schedule
-from typing import Callable, Dict
 
 
 class ScheduleManager:
-    """Manage scheduled jobs using the schedule package."""
+    """Manage scheduled jobs using the schedule package with SQLite persistence."""
 
-    def __init__(self) -> None:
+    def __init__(self, db_path: str = "data/schedules.db") -> None:
+        self.db_path = db_path
         self.jobs: Dict[str, schedule.Job] = {}
+        self._init_db()
+        self._load_tasks()
 
-    def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
-        """Add a job that runs every ``interval`` seconds."""
+    def add_task(
+        self, name: str, func: Callable, interval: int
+    ) -> schedule.Job:
+        """Add a job that runs every ``interval`` seconds and persist it."""
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
+        self._save_task(name, func, interval)
         return job
 
     def remove_task(self, name: str) -> bool:
@@ -21,6 +31,7 @@ class ScheduleManager:
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
+            self._delete_task(name)
             return True
         return False
 
@@ -32,3 +43,49 @@ class ScheduleManager:
         """Run all jobs that are scheduled to run."""
         schedule.run_pending()
 
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        """Initialize the schedules database."""
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS tasks ("
+                "name TEXT PRIMARY KEY,"
+                "module TEXT NOT NULL,"
+                "function TEXT NOT NULL,"
+                "interval INTEGER NOT NULL"
+                ")"
+            )
+
+    def _save_task(self, name: str, func: Callable, interval: int) -> None:
+        """Persist a task definition to the database."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "REPLACE INTO tasks (name, module, function, interval) VALUES (?, ?, ?, ?)",
+                (name, func.__module__, func.__name__, interval),
+            )
+
+    def _delete_task(self, name: str) -> None:
+        """Remove a task from the database."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
+
+    def _load_tasks(self) -> None:
+        """Load tasks from the database and schedule them."""
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT name, module, function, interval FROM tasks"
+            ).fetchall()
+
+        for name, module_name, func_name, interval in rows:
+            try:
+                module = importlib.import_module(module_name)
+                func = getattr(module, func_name)
+            except Exception:
+                # Skip invalid task definitions
+                continue
+            job = schedule.every(interval).seconds.do(func)
+            self.jobs[name] = job

--- a/tests/dummy_module.py
+++ b/tests/dummy_module.py
@@ -1,0 +1,8 @@
+"""Dummy module for schedule manager tests."""
+
+calls = []
+
+
+def dummy_task(x=None):
+    calls.append(x)
+    return x

--- a/tests/test_schedule_manager.py
+++ b/tests/test_schedule_manager.py
@@ -1,34 +1,63 @@
 import schedule
 from src.scheduling.schedule_manager import ScheduleManager
+from tests.dummy_module import dummy_task
 
 
 def dummy():
     pass
 
 
-def test_add_task():
+def test_add_task(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    db = tmp_path / "sched.db"
+    manager = ScheduleManager(db_path=str(db))
     job = manager.add_task("task1", dummy, 1)
     assert job in schedule.jobs
     assert manager.list_tasks()["task1"] is job
 
 
-def test_remove_task():
+def test_remove_task(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    db = tmp_path / "sched.db"
+    manager = ScheduleManager(db_path=str(db))
     job = manager.add_task("task1", dummy, 1)
     assert manager.remove_task("task1") is True
     assert job not in schedule.jobs
     assert manager.list_tasks() == {}
 
 
-def test_list_tasks_multiple():
+def test_list_tasks_multiple(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    db = tmp_path / "sched.db"
+    manager = ScheduleManager(db_path=str(db))
     job1 = manager.add_task("task1", dummy, 1)
     job2 = manager.add_task("task2", dummy, 2)
     tasks = manager.list_tasks()
     assert set(tasks.keys()) == {"task1", "task2"}
     assert tasks["task1"] is job1
     assert tasks["task2"] is job2
+
+
+def test_tasks_persist_between_instances(tmp_path):
+    schedule.clear()
+    db = tmp_path / "sched.db"
+    manager1 = ScheduleManager(db_path=str(db))
+    manager1.add_task("persist", dummy_task, 1)
+
+    schedule.clear()
+    manager2 = ScheduleManager(db_path=str(db))
+    tasks = manager2.list_tasks()
+    assert set(tasks.keys()) == {"persist"}
+    assert tasks["persist"].job_func.func == dummy_task
+
+
+def test_removed_task_not_loaded(tmp_path):
+    schedule.clear()
+    db = tmp_path / "sched.db"
+    manager1 = ScheduleManager(db_path=str(db))
+    manager1.add_task("persist", dummy_task, 1)
+    manager1.remove_task("persist")
+
+    schedule.clear()
+    manager2 = ScheduleManager(db_path=str(db))
+    assert manager2.list_tasks() == {}


### PR DESCRIPTION
## Summary
- persist scheduled jobs using SQLite in `ScheduleManager`
- add dummy module for persistence tests
- update schedule manager tests to use temporary DB and check persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d79ee7704833299e56dd3ae15688a