### PR TITLE
Implement output saving in multiple formats

### DIFF
--- a/src/scraping/output_manager.py
+++ b/src/scraping/output_manager.py
@@ -1,19 +1,72 @@
 """Handle output of scraped data."""
 
+from __future__ import annotations
+
+import csv
+import json
+import os
+from pathlib import Path
 from typing import Any
 
 
 class OutputManager:
-    """Placeholder for output handling."""
+    """Persist scraped data to files inside the ``output`` directory."""
 
-    def save(self, data: Any, path: str) -> None:
-        """Save scraped data to a file path.
+    BASE_DIR = Path("output")
+
+    def save(self, data: Any, path: str) -> bool:
+        """Save scraped ``data`` to ``path``.
+
+        The output format is determined from the file extension. Supported
+        extensions are ``.csv``, ``.json`` and ``.txt`` (or any other extension
+        for plain text).  ``path`` is created relative to the ``output``
+        directory if it is not an absolute path.  All necessary directories are
+        created automatically.
 
         Args:
-            data: Parsed data to persist.
-            path: Destination file path.
+            data: Parsed data to persist. ``data`` should be a sequence of
+                dictionaries for CSV output, any JSON serialisable object for
+                JSON output and a string or sequence of strings for plain text
+                output.
+            path: Destination file path or name.
 
         Returns:
-            None: This method does not return anything.
+            bool: ``True`` if the file was written successfully, ``False``
+            otherwise.
         """
-        pass
+
+        dest = Path(path)
+        if not dest.is_absolute():
+            dest = self.BASE_DIR / dest
+
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            ext = dest.suffix.lower()
+            if ext == ".json":
+                with dest.open("w", encoding="utf-8") as fp:
+                    json.dump(data, fp, indent=4)
+            elif ext == ".csv":
+                with dest.open("w", newline="", encoding="utf-8") as fp:
+                    if (
+                        isinstance(data, list)
+                        and data
+                        and isinstance(data[0], dict)
+                    ):
+                        writer = csv.DictWriter(fp, fieldnames=data[0].keys())
+                        writer.writeheader()
+                        writer.writerows(data)
+                    else:
+                        writer = csv.writer(fp)
+                        if isinstance(data, list):
+                            writer.writerows(data)
+                        else:
+                            writer.writerow([data])
+            else:
+                with dest.open("w", encoding="utf-8") as fp:
+                    if isinstance(data, list):
+                        fp.write("\n".join(str(item) for item in data))
+                    else:
+                        fp.write(str(data))
+            return True
+        except OSError:
+            return False

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -1,0 +1,41 @@
+import json
+import csv
+from pathlib import Path
+
+import pytest
+
+from src.scraping.output_manager import OutputManager
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return OutputManager()
+
+
+def test_save_json(manager):
+    data = {"name": "Alice", "age": 30}
+    assert manager.save(data, "data.json") is True
+    p = Path("output/data.json")
+    assert p.exists()
+    with p.open() as f:
+        assert json.load(f) == data
+
+
+def test_save_csv(manager):
+    data = [{"name": "A", "val": 1}, {"name": "B", "val": 2}]
+    assert manager.save(data, "items.csv") is True
+    p = Path("output/items.csv")
+    assert p.exists()
+    with p.open() as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert rows == [{"name": "A", "val": "1"}, {"name": "B", "val": "2"}]
+
+
+def test_save_text_nested(manager):
+    data = "Hello world"
+    assert manager.save(data, "nested/hello.txt") is True
+    p = Path("output/nested/hello.txt")
+    assert p.exists()
+    assert p.read_text() == data


### PR DESCRIPTION
## Summary
- implement CSV/JSON/text support in `OutputManager.save`
- auto-create directories under `output/`
- add unit tests for new formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7a019684833292c474011a43499a