### PR TITLE
Add SQLite schedule persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,10 +12,12 @@ def dummy_job() -> None:
 
 
 def main() -> None:
-    """Run the simple command-line scheduler demo."""
+    """Run the simple command-line scheduler demo with persistence."""
 
     manager = ScheduleManager()
-    manager.add_task("dummy", dummy_job, 5)
+
+    if not manager.list_tasks():
+        manager.add_task("dummy", dummy_job, 5)
 
     print("Scheduler started. Press Ctrl+C to exit.")
     try:
@@ -24,6 +26,8 @@ def main() -> None:
             time.sleep(1)
     except KeyboardInterrupt:
         print("\nScheduler stopped.")
+    finally:
+        manager.close()
 
 
 if __name__ == "__main__":

--- a/src/scheduling/schedule_manager.py
+++ b/src/scheduling/schedule_manager.py
@@ -1,19 +1,90 @@
-"""High-level interface for managing recurring tasks."""
+"""High-level interface for managing recurring tasks with persistence."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+from typing import Callable, Dict
 
 import schedule
-from typing import Callable, Dict
 
 
 class ScheduleManager:
-    """Manage scheduled jobs using the schedule package."""
+    """Manage scheduled jobs using the schedule package and SQLite."""
 
-    def __init__(self) -> None:
+    def __init__(self, db_path: str = "data/schedules.db") -> None:
+        """Initialize the manager and load tasks from ``db_path``.
+
+        The SQLite database is created automatically if it does not exist.
+        """
+
+        self.db_path = db_path
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
+
+        self._conn = sqlite3.connect(self.db_path)
+        self._init_db()
+
         self.jobs: Dict[str, schedule.Job] = {}
+        self._load_tasks()
+
+    # ------------------------------------------------------------------
+    # database handling
+    # ------------------------------------------------------------------
+
+    def _init_db(self) -> None:
+        """Create the tasks table if it doesn't exist."""
+
+        with self._conn:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    name TEXT PRIMARY KEY,
+                    module TEXT NOT NULL,
+                    func_name TEXT NOT NULL,
+                    interval INTEGER NOT NULL
+                )
+                """
+            )
+
+    def _load_tasks(self) -> None:
+        """Load all tasks from the database and schedule them."""
+
+        cursor = self._conn.execute(
+            "SELECT name, module, func_name, interval FROM tasks"
+        )
+        for name, module, func_name, interval in cursor.fetchall():
+            try:
+                mod = importlib.import_module(module)
+                func = getattr(mod, func_name)
+            except Exception:
+                # Skip tasks that can't be imported
+                continue
+            job = schedule.every(interval).seconds.do(func)
+            self.jobs[name] = job
+
+    def _persist_task(self, name: str, func: Callable, interval: int) -> None:
+        """Persist a task definition to the database."""
+
+        with self._conn:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
+                " VALUES (?, ?, ?, ?)",
+                (name, func.__module__, func.__name__, interval),
+            )
+
+    def _delete_task(self, name: str) -> None:
+        """Remove a task from the database."""
+
+        with self._conn:
+            self._conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
 
     def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
-        """Add a job that runs every ``interval`` seconds."""
+        """Add a job that runs every ``interval`` seconds and persist it."""
+
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
+        self._persist_task(name, func, interval)
         return job
 
     def remove_task(self, name: str) -> bool:
@@ -21,6 +92,7 @@ class ScheduleManager:
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
+            self._delete_task(name)
             return True
         return False
 
@@ -31,4 +103,9 @@ class ScheduleManager:
     def run_pending(self) -> None:
         """Run all jobs that are scheduled to run."""
         schedule.run_pending()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+
+        self._conn.close()
 

--- a/tests/test_schedule_manager.py
+++ b/tests/test_schedule_manager.py
@@ -6,29 +6,49 @@ def dummy():
     pass
 
 
-def test_add_task():
+def test_add_task(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    manager = ScheduleManager(db_path=str(tmp_path / "sched.db"))
     job = manager.add_task("task1", dummy, 1)
     assert job in schedule.jobs
     assert manager.list_tasks()["task1"] is job
+    manager.close()
 
 
-def test_remove_task():
+def test_remove_task(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    manager = ScheduleManager(db_path=str(tmp_path / "sched.db"))
     job = manager.add_task("task1", dummy, 1)
     assert manager.remove_task("task1") is True
     assert job not in schedule.jobs
     assert manager.list_tasks() == {}
+    manager.close()
 
 
-def test_list_tasks_multiple():
+def test_list_tasks_multiple(tmp_path):
     schedule.clear()
-    manager = ScheduleManager()
+    manager = ScheduleManager(db_path=str(tmp_path / "sched.db"))
     job1 = manager.add_task("task1", dummy, 1)
     job2 = manager.add_task("task2", dummy, 2)
     tasks = manager.list_tasks()
     assert set(tasks.keys()) == {"task1", "task2"}
     assert tasks["task1"] is job1
     assert tasks["task2"] is job2
+    manager.close()
+
+
+def test_persistence(tmp_path):
+    """Tasks should be reloaded from the SQLite database."""
+
+    db = tmp_path / "sched.db"
+    schedule.clear()
+    manager = ScheduleManager(db_path=str(db))
+    manager.add_task("task1", dummy, 1)
+    manager.close()
+
+    schedule.clear()
+    manager2 = ScheduleManager(db_path=str(db))
+    assert "task1" in manager2.list_tasks()
+    job = manager2.list_tasks()["task1"]
+    assert job in schedule.jobs
+    manager2.close()


### PR DESCRIPTION
## Summary
- persist tasks to an SQLite file in `ScheduleManager`
- load tasks on startup via importlib
- demo script now reloads tasks if any exist
- add tests for persistence behaviour
- include a `data/` directory placeholder

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d79f6fe20833290ef8047f60fa1c3