### PR TITLE
Add GUI and engine tests

### DIFF
--- a/tests/test_file_and_logging_utils.py
+++ b/tests/test_file_and_logging_utils.py
@@ -1,0 +1,14 @@
+import builtins
+from src.utils.file_handler import FileHandler
+from src.utils.logger import Logger
+
+
+def test_file_handler_methods_return_none(tmp_path):
+    fh = FileHandler()
+    assert fh.read(str(tmp_path / 'file.txt')) is None
+    assert fh.write(str(tmp_path / 'file.txt'), 'data') is None
+
+
+def test_logger_log_returns_none():
+    logger = Logger()
+    assert logger.log('message') is None

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -1,0 +1,25 @@
+from src.gui.main_window import MainWindow
+from src.gui.scheduler_dialog import SchedulerDialog
+from src.gui.settings_panel import SettingsPanel
+from src.gui.website_manager import WebsiteManager
+
+
+def test_main_window_show_returns_none():
+    window = MainWindow()
+    assert window.show() is None
+
+
+def test_scheduler_dialog_open_returns_none():
+    dialog = SchedulerDialog()
+    assert dialog.open() is None
+
+
+def test_settings_panel_open_returns_none():
+    panel = SettingsPanel()
+    assert panel.open() is None
+
+
+def test_website_manager_methods_return_none():
+    manager = WebsiteManager()
+    assert manager.add_website('http://example.com') is None
+    assert manager.remove_website('http://example.com') is None

--- a/tests/test_schedule_manager_run_pending.py
+++ b/tests/test_schedule_manager_run_pending.py
@@ -1,0 +1,14 @@
+import schedule
+from src.scheduling.schedule_manager import ScheduleManager
+
+
+def test_run_pending_calls_schedule(monkeypatch):
+    called = []
+
+    def fake_run_pending():
+        called.append(True)
+
+    monkeypatch.setattr(schedule, "run_pending", fake_run_pending)
+    manager = ScheduleManager()
+    manager.run_pending()
+    assert called == [True]

--- a/tests/test_scraper_engine.py
+++ b/tests/test_scraper_engine.py
@@ -1,0 +1,6 @@
+from src.scraping.scraper_engine import ScraperEngine
+
+
+def test_scraper_engine_scrape_returns_none():
+    engine = ScraperEngine()
+    assert engine.scrape('http://example.com') is None


### PR DESCRIPTION
## Summary
- test file and logging utilities
- test minimal GUI hooks
- cover scraper engine
- cover schedule manager's `run_pending`

## Testing
- `pytest -q`
- `pytest --cov=src --cov-report xml -q`

------
https://chatgpt.com/codex/tasks/task_e_686d79fa875c83329b70f744d5419039