### PR TITLE
🚨 URGENT: Add Missing Logger Class - Fix Critical CI Failures

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -19,6 +19,29 @@ logging.basicConfig(
 )
 
 
+class Logger:
+    """Logger class for compatibility with tests."""
+    
+    def __init__(self, name: str | None = None) -> None:
+        """Initialize the Logger.
+        
+        Args:
+            name: Name of the logger.
+        """
+        self._logger = logging.getLogger(name)
+    
+    def log(self, message: str) -> None:
+        """Log a message.
+        
+        Args:
+            message: Text message to log.
+            
+        Returns:
+            None: This method does not return anything.
+        """
+        self._logger.info(message)
+
+
 def get_logger(name: str | None = None) -> logging.Logger:
     """Return a configured logger instance."""
 
@@ -36,4 +59,3 @@ def log_exception(logger: logging.Logger, message: str, exc: Exception) -> None:
 
     logger.error(message)
     logger.exception(exc)
-


### PR DESCRIPTION
## 🚨 Critical CI Fix: Add Missing Logger Class

**Problem**: All CI builds failing due to `ImportError: cannot import name 'Logger' from 'src.utils.logger'`

**Root Cause**: The test file `tests/test_file_and_logging_utils.py` expects a `Logger` class with a `log` method, but the current `logger.py` only provides functions.

**Solution**:
✅ **Added Logger class** with `log` method that returns `None` (as required by tests)  
✅ **Maintained backward compatibility** with existing `get_logger()` function  
✅ **Uses standard Python logging** internally for proper logging functionality  
✅ **Fixes the specific ImportError** blocking all CI builds  

**Impact**:
- **Resolves CI failures** across all PRs  
- **Unblocks development workflow** - enables other PRs to be merged  
- **No breaking changes** - existing code continues to work  

**Testing**:
- This fixes the failing test: `tests/test_file_and_logging_utils.py`
- All existing logging functionality preserved
- New Logger class passes test expectations

**Priority**: 🔥 **URGENT** - This unblocks all development work

---
*Auto-generated by GitHub MCP Agent - Critical CI Management*