### PR TITLE
Refactor file handler

### DIFF
--- a/cinder_web_scraper/utils/file_handler.py
+++ b/cinder_web_scraper/utils/file_handler.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
-
 from pathlib import Path
 
 from .logger import default_logger as logger
@@ -32,23 +29,13 @@ class FileHandler:
             OSError: For any other I/O related errors.
         """
         try:
-
             with open(path, "r", encoding="utf-8") as fp:
                 content = fp.read()
             logger.log(f"Read file: {path}")
             return content
-        except OSError as exc:
+        except (FileNotFoundError, PermissionError, OSError) as exc:
             logger.log(f"Failed to read file {path}: {exc}")
             raise
-
-            with open(path, "r", encoding="utf-8") as fh:
-                return fh.read()
-        except FileNotFoundError:
-            raise
-        except PermissionError:
-            raise
-        except OSError as exc:
-            raise OSError(f"Failed to read '{path}'") from exc
 
 
     def write(self, path: str, data: str) -> None:
@@ -65,20 +52,11 @@ class FileHandler:
             OSError: For any other I/O related errors.
         """
         try:
-
             Path(path).parent.mkdir(parents=True, exist_ok=True)
             with open(path, "w", encoding="utf-8") as fp:
                 fp.write(data)
             logger.log(f"Wrote file: {path}")
-        except OSError as exc:
+        except (PermissionError, OSError) as exc:
             logger.log(f"Failed to write file {path}: {exc}")
             raise
-
-            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-            with open(path, "w", encoding="utf-8") as fh:
-                fh.write(data)
-        except PermissionError:
-            raise
-        except OSError as exc:
-            raise OSError(f"Failed to write to '{path}'") from exc
 


### PR DESCRIPTION
## Summary
- simplify `read` and `write` helper methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `src` packages)*

------
https://chatgpt.com/codex/tasks/task_e_686e4cc5ff708332919d4bfa3a41621c