### PR TITLE
Fix invalid websites.json example

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -1,7 +1,11 @@
-
-[]
-
-{
-    "foo": "bar"
-}
-
+[
+    {
+        "name": "Example Site",
+        "url": "https://example.com",
+        "selectors": {
+            "title": "h1",
+            "content": ".content"
+        },
+        "interval": 3600
+    }
+]


### PR DESCRIPTION
## Summary
- replace bogus websites.json contents with a valid JSON array example

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686e4ccb5a40833288d425ae5e3d0d9c