### PR TITLE
Add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "schedule==1.2.2",
+    "requests",
+    "beautifulsoup4",
 ]
 
 [project.scripts]
@@ -21,5 +23,4 @@ dev = [
     "pytest==8.4.0",
 ]
 
-[tool.setuptools.packages.find]
-where = ["."]
+[tool.setuptools.packages.find]where = ["."]


### PR DESCRIPTION
## Summary
- extend project dependencies for requests and beautifulsoup4

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686e4ccbdb5483329e995f53ca3e2516