### PR TITLE
Fix documentation package references

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ project_root/
 │   ├── schedules.db
 │   └── logs/
 ├── output/    # Scraped data is written here
-└── src/       # Application code
+└── cinder_web_scraper/       # Application code
 ```
 
 `data/` holds user configuration and log files while all scraped results are written to `output/`.
@@ -113,7 +113,7 @@ project_root/
 - `save_config(data, path=None)` – Save a configuration dictionary to ``path``. When ``path`` is omitted the data is written to `data/websites.json`.
 
 
-The `config_manager` module in `src/utils` provides convenience functions:
+The `config_manager` module in `cinder_web_scraper/utils` provides convenience functions:
 
 ```python
 from cinder_web_scraper.utils.config_manager import load_config, save_config
@@ -157,10 +157,10 @@ You will see a simple loop that executes a dummy job every few seconds.
 
 ### GUI application
 
-The GUI components live in `src/gui`. During development you can launch the (placeholder) main window with:
+The GUI components live in `cinder_web_scraper/gui`. During development you can launch the (placeholder) main window with:
 
 ```bash
-python -m src.gui.main_window
+python -m cinder_web_scraper.gui.main_window
 ```
 
 As features are implemented, this will provide buttons to manage websites, scheduling options, and view logs.
@@ -202,7 +202,7 @@ can experiment with the placeholder window using the following snippet:
 
 ```bash
 python - <<'PY'
-from src.gui.main_window import MainWindow
+from cinder_web_scraper.gui.main_window import MainWindow
 
 window = MainWindow()
 window.show()
@@ -235,10 +235,10 @@ path in your configuration file.
 
 ## Launching the GUI
 
-A basic Tkinter interface is provided in `src/gui`. To start the GUI, run:
+A basic Tkinter interface is provided in `cinder_web_scraper/gui`. To start the GUI, run:
 
 ```bash
-python -m src.gui.main_window
+python -m cinder_web_scraper.gui.main_window
 ```
 
 The GUI currently contains placeholder widgets but demonstrates how to integrate the scheduling system. The recent tasks added docstrings and type hints across these modules, making it easier to understand and extend the GUI code.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -5,16 +5,16 @@ This document provides an overview of the code base, contribution process and a 
 ## Code Structure
 
 ```
-src/
+cinder_web_scraper/
 ├── gui/                # Tkinter GUI components
 ├── scraping/           # Future scraping engine
 ├── scheduling/         # Task scheduling modules
 ├── utils/              # Utility helpers
 ```
 
-- **src/gui** – Placeholder classes for the Tkinter interface such as `MainWindow`, `WebsiteManager`, `SchedulerDialog` and `SettingsPanel`.
-- **src/scheduling** – Implements simple scheduling logic. `ScheduleManager` wraps the [`schedule`](https://pypi.org/project/schedule/) library and `TaskScheduler` provides an in-memory queue.
-- **src/utils** – Helper modules such as `config_manager` for reading/writing JSON config files.
+- **cinder_web_scraper.gui** – Placeholder classes for the Tkinter interface such as `MainWindow`, `WebsiteManager`, `SchedulerDialog` and `SettingsPanel`.
+- **cinder_web_scraper.scheduling** – Implements simple scheduling logic. `ScheduleManager` wraps the [`schedule`](https://pypi.org/project/schedule/) library and `TaskScheduler` provides an in-memory queue.
+- **cinder_web_scraper.utils** – Helper modules such as `config_manager` for reading/writing JSON config files.
 
 ## Contributing
 
@@ -27,19 +27,19 @@ We follow standard Python style with informative docstrings. Please keep commit 
 
 ## API Reference
 
-### `src.utils.config_manager`
+### `cinder_web_scraper.utils.config_manager`
 
 - `load_config(path)` – Return a configuration dictionary from `path`. If the file does not exist or is malformed, default settings are returned.
 - `save_config(data, path)` – Save a configuration dictionary to the given path. Returns `True` on success.
 
-### `src.scheduling.schedule_manager`
+### `cinder_web_scraper.scheduling.schedule_manager`
 
 - `add_task(name, func, interval)` – Schedule `func` to run every `interval` seconds. Returns the created job object.
 - `remove_task(name)` – Cancel a scheduled job by name. Returns `True` if removed.
 - `list_tasks()` – Return a mapping of task names to jobs.
 - `run_pending()` – Execute any tasks that are due to run.
 
-### `src.scheduling.task_scheduler`
+### `cinder_web_scraper.scheduling.task_scheduler`
 
 - `add_task(func, *args, **kwargs)` – Queue a callable with optional arguments.
 - `run_all()` – Execute queued callables in order and clear the queue.


### PR DESCRIPTION
- Updated README to reference `cinder_web_scraper.gui.main_window` in command examples and directory layout.
- Revised developer guide to use `cinder_web_scraper` namespace throughout the code structure and API reference.


------
https://chatgpt.com/codex/tasks/task_e_686e4ccd5e188332b1be4c1e9c8a875f