### PR TITLE
Fix duplicate logger and rebuild schedule manager

### DIFF
--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -1,55 +1,70 @@
-"""High-level interface for managing recurring tasks with persistence."""
-
-import os
-import sqlite3
-from typing import Callable, Dict, List, Optional
-
-import schedule
-
+"""Simple wrapper around the ``schedule`` package with SQLite persistence."""
 
 from __future__ import annotations
 
 import importlib
 import os
 import sqlite3
-from typing import Callable, Dict
+from typing import Callable, Dict, List, Optional
+
+import schedule
 
 from src.utils.logger import default_logger as logger
 
 
-import schedule
-
-
 class ScheduleManager:
-
-    """Manage scheduled jobs using the schedule package with SQLite persistence."""
+    """Manage scheduled tasks and persist them to SQLite."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and ensure the SQLite table exists."""
-        self.jobs: Dict[str, schedule.Job] = {}
         self.db_path = db_path
-        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
         self.conn = sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS schedules (name TEXT PRIMARY KEY, interval INTEGER)"
+            """
+            CREATE TABLE IF NOT EXISTS schedules (
+                name TEXT PRIMARY KEY,
+                module TEXT NOT NULL,
+                func_name TEXT NOT NULL,
+                interval INTEGER NOT NULL
+            )
+            """
         )
         self.conn.commit()
+        self.jobs: Dict[str, schedule.Job] = {}
+        self._load_tasks()
 
     # ------------------------------------------------------------------
-    # SQLite CRUD operations
+    # database helpers
+    # ------------------------------------------------------------------
+
+    def _load_tasks(self) -> None:
+        """Load persisted tasks from the database."""
+        cursor = self.conn.execute(
+            "SELECT name, module, func_name, interval FROM schedules"
+        )
+        for name, module, func_name, interval in cursor.fetchall():
+            try:
+                mod = importlib.import_module(module)
+                func = getattr(mod, func_name)
+            except Exception:
+                # Skip tasks that cannot be imported
+                continue
+            job = schedule.every(interval).seconds.do(func)
+            self.jobs[name] = job
+
+    # ------------------------------------------------------------------
+    # CRUD operations
     # ------------------------------------------------------------------
 
     def create_schedule(self, name: str, interval: int) -> None:
-        """Insert a schedule record."""
         with self.conn:
             self.conn.execute(
-                "INSERT INTO schedules (name, interval) VALUES (?, ?)",
-                (name, interval),
+                "INSERT INTO schedules (name, module, func_name, interval) VALUES (?, ?, ?, ?)",
+                (name, "", "", interval),
             )
 
     def get_schedule(self, name: str) -> Optional[Dict[str, int]]:
-        """Retrieve a schedule record by name."""
         cur = self.conn.execute(
             "SELECT name, interval FROM schedules WHERE name = ?",
             (name,),
@@ -60,7 +75,6 @@ class ScheduleManager:
         return None
 
     def update_schedule(self, name: str, interval: int) -> bool:
-        """Update the interval for a schedule."""
         with self.conn:
             cur = self.conn.execute(
                 "UPDATE schedules SET interval = ? WHERE name = ?",
@@ -69,7 +83,6 @@ class ScheduleManager:
             return cur.rowcount > 0
 
     def delete_schedule(self, name: str) -> bool:
-        """Delete a schedule record."""
         with self.conn:
             cur = self.conn.execute(
                 "DELETE FROM schedules WHERE name = ?",
@@ -78,136 +91,50 @@ class ScheduleManager:
             return cur.rowcount > 0
 
     def list_schedules(self) -> List[Dict[str, int]]:
-        """Return all schedules stored in the database."""
         cur = self.conn.execute("SELECT name, interval FROM schedules")
         return [
             {"name": row["name"], "interval": row["interval"]}
             for row in cur.fetchall()
         ]
 
-    def __del__(self) -> None:
-        """Close the database connection when the manager is deleted."""
-        try:
-            self.conn.close()
-        except Exception:
-            pass
+    # ------------------------------------------------------------------
+    # scheduling operations
+    # ------------------------------------------------------------------
 
     def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
-
-        logger.log(f"Added task '{name}' to run every {interval} seconds")
-
         with self.conn:
             self.conn.execute(
-                "INSERT OR REPLACE INTO schedules (name, interval) VALUES (?, ?)",
-                (name, interval),
+                "INSERT OR REPLACE INTO schedules (name, module, func_name, interval) VALUES (?, ?, ?, ?)",
+                (name, func.__module__, func.__name__, interval),
             )
-
+        logger.log(f"Added task '{name}' to run every {interval} seconds")
         return job
 
     def remove_task(self, name: str) -> bool:
-        """Remove a scheduled job by name and delete its record."""
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
             self.delete_schedule(name)
-
-    """Manage scheduled jobs using the schedule package and SQLite."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load tasks from ``db_path``.
-
-        The SQLite database is created automatically if it does not exist.
-        """
-        self.db_path = db_path
-        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
-
-        self._conn = sqlite3.connect(self.db_path)
-        self._init_db()
-
-        self.jobs: Dict[str, schedule.Job] = {}
-        self._load_tasks()
-
-    # ------------------------------------------------------------------
-    # database handling
-    # ------------------------------------------------------------------
-
-    def _init_db(self) -e None:
-        """Create the tasks table if it doesn't exist."""
-        with self._conn:
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS tasks (
-                    name TEXT PRIMARY KEY,
-                    module TEXT NOT NULL,
-                    func_name TEXT NOT NULL,
-                    interval INTEGER NOT NULL
-                )
-                """
-            )
-
-    def _load_tasks(self) -e None:
-        """Load all tasks from the database and schedule them."""
-        cursor = self._conn.execute(
-            "SELECT name, module, func_name, interval FROM tasks"
-        )
-        for name, module, func_name, interval in cursor.fetchall():
-            try:
-                mod = importlib.import_module(module)
-                func = getattr(mod, func_name)
-            except Exception:
-                # Skip tasks that can't be imported
-                continue
-            job = schedule.every(interval).seconds.do(func)
-            self.jobs[name] = job
-
-    def _persist_task(self, name: str, func: Callable, interval: int) -e None:
-        """Persist a task definition to the database."""
-        with self._conn:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
-                " VALUES (?, ?, ?, ?)",
-                (name, func.__module__, func.__name__, interval),
-            )
-
-    def _delete_task(self, name: str) -e None:
-        """Remove a task from the database."""
-        with self._conn:
-            self._conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
-
-    def add_task(self, name: str, func: Callable, interval: int) -e schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
-        job = schedule.every(interval).seconds.do(func)
-        self.jobs[name] = job
-        self._persist_task(name, func, interval)
-        return job
-
-    def remove_task(self, name: str) -e bool:
-        """Remove a scheduled job by name."""
-        job = self.jobs.pop(name, None)
-        if job:
-            schedule.cancel_job(job)
             logger.log(f"Removed task '{name}'")
-
-            self._delete_task(name)
-
-
             return True
         logger.log(f"Attempted to remove unknown task '{name}'")
         return False
 
-    def list_tasks(self) -e Dict[str, schedule.Job]:
-        """Return a mapping of task names to jobs."""
+    def list_tasks(self) -> Dict[str, schedule.Job]:
         logger.log("Listing scheduled tasks")
         return dict(self.jobs)
 
-    def run_pending(self) -e None:
-        """Run all jobs that are scheduled to run."""
+    def run_pending(self) -> None:
         logger.log("Running pending scheduled tasks")
         schedule.run_pending()
 
-    def close(self) -e None:
-        """Close the underlying SQLite connection."""
-        self._conn.close()
+    def close(self) -> None:
+        self.conn.close()
+
+    def __del__(self) -> None:  # pragma: no cover - cleanup
+        try:
+            self.conn.close()
+        except Exception:
+            pass

--- a/main.py
+++ b/main.py
@@ -7,15 +7,11 @@ import traceback
 
 from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 from cinder_web_scraper.utils.logger import default_logger as logger
-from cinder_web_scraper.utils.logger import get_logger
 
 
 def dummy_job() -> None:
     """Example job that prints a message."""
     logger.log("Dummy job executed")
-
-
-logger = get_logger(__name__)
 
 
 def main() -> None:

--- a/src
+++ b/src
@@ -1,0 +1,1 @@
+cinder_web_scraper


### PR DESCRIPTION
## Summary
- use only the default logger in `main.py`
- replace corrupted `schedule_manager.py` with a clean implementation
- create `src` symlink for imports used in tests

## Testing
- `pytest -q` *(fails: TypeError in ContentExtractor and others)*

------
https://chatgpt.com/codex/tasks/task_e_686e4cd9eaec8332acc4c135d9f030bd