### PR TITLE
Fix pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "schedule==1.2.2",
+    "requests",
+    "beautifulsoup4",
 ]
 
 [project.scripts]
@@ -21,5 +23,4 @@ dev = [
     "pytest==8.4.0",
 ]
 
-[tool.setuptools.packages.find]
-where = ["."]
+[tool.setuptools.packages.find]where = ["."]


### PR DESCRIPTION
## Summary
- include `requests` and `beautifulsoup4` in project dependencies

## Testing
- `pip install .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686e4cdacfa083328b3d58ecc97071a7