### PR TITLE
Fix broken websites.json and document schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,27 @@ Configuration data is stored under the `data/` directory:
 - `data/websites.json` – Individual website profiles
 - `data/schedules.db` – Planned job database
 
+### Website profile schema
+
+Each entry in `data/websites.json` follows this structure:
+
+```json
+{
+  "websites": [
+    {
+      "name": "Example Site",
+      "url": "https://example.com",
+      "selectors": {
+        "title": "h1",
+        "content": ".content"
+      },
+      "interval": 3600
+    }
+  ],
+  "settings": {}
+}
+```
+
 These files are created automatically when saving via `config_manager` or scheduling utilities. Logs are written to `data/logs/`.
 
 ## Example Scraping Workflow

--- a/data/websites.json
+++ b/data/websites.json
@@ -1,7 +1,4 @@
-
-[]
-
 {
-    "foo": "bar"
+    "websites": [],
+    "settings": {}
 }
-


### PR DESCRIPTION
## Summary
- make `data/websites.json` valid JSON
- describe `websites.json` format in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686e4cf048c88332bbba716baff8b439