### PR TITLE
Update tests to use new package path

### DIFF
--- a/cinder_web_scraper/gui/main_window.py
+++ b/cinder_web_scraper/gui/main_window.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Callable, Optional
 
-from src.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.logger import get_logger, log_exception
 
 logger = get_logger(__name__)
 

--- a/cinder_web_scraper/gui/settings_panel.py
+++ b/cinder_web_scraper/gui/settings_panel.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any, Dict
 
-from src.utils import config_manager
+from cinder_web_scraper.utils import config_manager
 
 
 class SettingsPanel:

--- a/cinder_web_scraper/main.py
+++ b/cinder_web_scraper/main.py
@@ -2,7 +2,7 @@
 
 import time
 
-from src.scheduling.schedule_manager import ScheduleManager
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 
 
 def dummy_job() -> None:

--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -1,45 +1,91 @@
-"""High-level interface for managing recurring tasks with persistence."""
+from __future__ import annotations
 
+"""Scheduling manager with SQLite persistence."""
+
+import importlib
 import os
 import sqlite3
 from typing import Callable, Dict, List, Optional
 
 import schedule
 
-
-from __future__ import annotations
-
-import importlib
-import os
-import sqlite3
-from typing import Callable, Dict
-
-from src.utils.logger import default_logger as logger
-
-
-import schedule
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class ScheduleManager:
-
-    """Manage scheduled jobs using the schedule package with SQLite persistence."""
+    """Manage scheduled tasks using :mod:`schedule` with persistent storage."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and ensure the SQLite table exists."""
-        self.jobs: Dict[str, schedule.Job] = {}
+        """Initialize the manager and load tasks from ``db_path``.
+
+        The SQLite database is created automatically if it does not exist.
+        """
         self.db_path = db_path
-        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
+
         self.conn = sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS schedules (name TEXT PRIMARY KEY, interval INTEGER)"
+        self._init_db()
+
+        self.jobs: Dict[str, schedule.Job] = {}
+        self._load_tasks()
+
+    # ------------------------------------------------------------------
+    # Database setup and helpers
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        """Create required tables if they don't exist."""
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schedules (
+                    name TEXT PRIMARY KEY,
+                    interval INTEGER NOT NULL
+                )
+                """
+            )
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    name TEXT PRIMARY KEY,
+                    module TEXT NOT NULL,
+                    func_name TEXT NOT NULL,
+                    interval INTEGER NOT NULL
+                )
+                """
+            )
+
+    def _load_tasks(self) -> None:
+        """Load persisted tasks from the database and schedule them."""
+        cursor = self.conn.execute(
+            "SELECT name, module, func_name, interval FROM tasks"
         )
-        self.conn.commit()
+        for name, module, func_name, interval in cursor.fetchall():
+            try:
+                mod = importlib.import_module(module)
+                func = getattr(mod, func_name)
+            except Exception:
+                continue
+            job = schedule.every(interval).seconds.do(func)
+            self.jobs[name] = job
+
+    def _persist_task(self, name: str, func: Callable, interval: int) -> None:
+        """Persist task definition to the database."""
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
+                " VALUES (?, ?, ?, ?)",
+                (name, func.__module__, func.__name__, interval),
+            )
+
+    def _delete_task(self, name: str) -> None:
+        """Remove a task record from the database."""
+        with self.conn:
+            self.conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
 
     # ------------------------------------------------------------------
-    # SQLite CRUD operations
+    # Public API
     # ------------------------------------------------------------------
-
     def create_schedule(self, name: str, interval: int) -> None:
         """Insert a schedule record."""
         with self.conn:
@@ -49,7 +95,7 @@ class ScheduleManager:
             )
 
     def get_schedule(self, name: str) -> Optional[Dict[str, int]]:
-        """Retrieve a schedule record by name."""
+        """Retrieve a schedule record by ``name``."""
         cur = self.conn.execute(
             "SELECT name, interval FROM schedules WHERE name = ?",
             (name,),
@@ -60,7 +106,7 @@ class ScheduleManager:
         return None
 
     def update_schedule(self, name: str, interval: int) -> bool:
-        """Update the interval for a schedule."""
+        """Update the interval for ``name``."""
         with self.conn:
             cur = self.conn.execute(
                 "UPDATE schedules SET interval = ? WHERE name = ?",
@@ -69,7 +115,7 @@ class ScheduleManager:
             return cur.rowcount > 0
 
     def delete_schedule(self, name: str) -> bool:
-        """Delete a schedule record."""
+        """Delete a schedule by ``name``."""
         with self.conn:
             cur = self.conn.execute(
                 "DELETE FROM schedules WHERE name = ?",
@@ -85,129 +131,35 @@ class ScheduleManager:
             for row in cur.fetchall()
         ]
 
-    def __del__(self) -> None:
-        """Close the database connection when the manager is deleted."""
-        try:
-            self.conn.close()
-        except Exception:
-            pass
-
     def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
+        """Schedule ``func`` to run every ``interval`` seconds and persist it."""
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
-
+        self.create_schedule(name, interval)
+        self._persist_task(name, func, interval)
         logger.log(f"Added task '{name}' to run every {interval} seconds")
-
-        with self.conn:
-            self.conn.execute(
-                "INSERT OR REPLACE INTO schedules (name, interval) VALUES (?, ?)",
-                (name, interval),
-            )
-
         return job
 
     def remove_task(self, name: str) -> bool:
-        """Remove a scheduled job by name and delete its record."""
+        """Remove a scheduled job by ``name``."""
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
             self.delete_schedule(name)
-
-    """Manage scheduled jobs using the schedule package and SQLite."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load tasks from ``db_path``.
-
-        The SQLite database is created automatically if it does not exist.
-        """
-        self.db_path = db_path
-        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
-
-        self._conn = sqlite3.connect(self.db_path)
-        self._init_db()
-
-        self.jobs: Dict[str, schedule.Job] = {}
-        self._load_tasks()
-
-    # ------------------------------------------------------------------
-    # database handling
-    # ------------------------------------------------------------------
-
-    def _init_db(self) -e None:
-        """Create the tasks table if it doesn't exist."""
-        with self._conn:
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS tasks (
-                    name TEXT PRIMARY KEY,
-                    module TEXT NOT NULL,
-                    func_name TEXT NOT NULL,
-                    interval INTEGER NOT NULL
-                )
-                """
-            )
-
-    def _load_tasks(self) -e None:
-        """Load all tasks from the database and schedule them."""
-        cursor = self._conn.execute(
-            "SELECT name, module, func_name, interval FROM tasks"
-        )
-        for name, module, func_name, interval in cursor.fetchall():
-            try:
-                mod = importlib.import_module(module)
-                func = getattr(mod, func_name)
-            except Exception:
-                # Skip tasks that can't be imported
-                continue
-            job = schedule.every(interval).seconds.do(func)
-            self.jobs[name] = job
-
-    def _persist_task(self, name: str, func: Callable, interval: int) -e None:
-        """Persist a task definition to the database."""
-        with self._conn:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
-                " VALUES (?, ?, ?, ?)",
-                (name, func.__module__, func.__name__, interval),
-            )
-
-    def _delete_task(self, name: str) -e None:
-        """Remove a task from the database."""
-        with self._conn:
-            self._conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
-
-    def add_task(self, name: str, func: Callable, interval: int) -e schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
-        job = schedule.every(interval).seconds.do(func)
-        self.jobs[name] = job
-        self._persist_task(name, func, interval)
-        return job
-
-    def remove_task(self, name: str) -e bool:
-        """Remove a scheduled job by name."""
-        job = self.jobs.pop(name, None)
-        if job:
-            schedule.cancel_job(job)
-            logger.log(f"Removed task '{name}'")
-
             self._delete_task(name)
-
-
+            logger.log(f"Removed task '{name}'")
             return True
         logger.log(f"Attempted to remove unknown task '{name}'")
         return False
 
-    def list_tasks(self) -e Dict[str, schedule.Job]:
+    def list_tasks(self) -> Dict[str, schedule.Job]:
         """Return a mapping of task names to jobs."""
-        logger.log("Listing scheduled tasks")
         return dict(self.jobs)
 
-    def run_pending(self) -e None:
-        """Run all jobs that are scheduled to run."""
-        logger.log("Running pending scheduled tasks")
+    def run_pending(self) -> None:
+        """Execute all pending jobs."""
         schedule.run_pending()
 
-    def close(self) -e None:
-        """Close the underlying SQLite connection."""
-        self._conn.close()
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        self.conn.close()

--- a/cinder_web_scraper/scheduling/task_scheduler.py
+++ b/cinder_web_scraper/scheduling/task_scheduler.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Callable, Dict, List, Tuple
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class TaskScheduler:

--- a/cinder_web_scraper/scraping/content_extractor.py
+++ b/cinder_web_scraper/scraping/content_extractor.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ContentExtractor:
     """Parse HTML and return structured data or text from selected elements."""

--- a/cinder_web_scraper/scraping/output_manager.py
+++ b/cinder_web_scraper/scraping/output_manager.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class OutputManager:

--- a/cinder_web_scraper/scraping/scraper_engine.py
+++ b/cinder_web_scraper/scraping/scraper_engine.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 from .content_extractor import ContentExtractor
 from .output_manager import OutputManager
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ScraperEngine:
     """Download pages and extract data using provided helpers with retry support."""

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1,5 +1,5 @@
 import pytest
-from src.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
 
 
 def test_basic_html():

--- a/tests/test_file_and_logging_utils.py
+++ b/tests/test_file_and_logging_utils.py
@@ -1,6 +1,6 @@
 import builtins
-from src.utils.file_handler import FileHandler
-from src.utils.logger import get_logger
+from cinder_web_scraper.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.logger import get_logger
 
 
 def test_file_handler_methods_return_none(tmp_path):

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -1,5 +1,5 @@
 
-from src.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.file_handler import FileHandler
 
 
 def test_read_write(tmp_path):
@@ -15,7 +15,7 @@ import os
 
 import pytest
 
-from src.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.file_handler import FileHandler
 
 
 @pytest.fixture()

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,7 +1,7 @@
-from src.gui.main_window import MainWindow
-from src.gui.scheduler_dialog import SchedulerDialog
-from src.gui.settings_panel import SettingsPanel
-from src.gui.website_manager import WebsiteManager
+from cinder_web_scraper.gui.main_window import MainWindow
+from cinder_web_scraper.gui.scheduler_dialog import SchedulerDialog
+from cinder_web_scraper.gui.settings_panel import SettingsPanel
+from cinder_web_scraper.gui.website_manager import WebsiteManager
 
 
 def test_main_window_show():

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -1,14 +1,14 @@
 import os
 import pytest
 from unittest.mock import patch, MagicMock
-from src.gui.main_window import MainWindow
-from src.gui.scheduler_dialog import SchedulerDialog
-from src.gui.settings_panel import SettingsPanel
-from src.gui.website_manager import WebsiteManager
+from cinder_web_scraper.gui.main_window import MainWindow
+from cinder_web_scraper.gui.scheduler_dialog import SchedulerDialog
+from cinder_web_scraper.gui.settings_panel import SettingsPanel
+from cinder_web_scraper.gui.website_manager import WebsiteManager
 
 
 @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Skipping GUI tests in CI environment')
-@patch('src.gui.main_window.tk')
+@patch('cinder_web_scraper.gui.main_window.tk')
 def test_main_window_show_returns_none(mock_tk):
     # Mock tkinter to avoid display issues in CI
     mock_tk.Tk.return_value = MagicMock()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,5 @@
 
-from src.utils.logger import Logger
+from cinder_web_scraper.utils.logger import Logger
 
 
 def test_log_output(tmp_path):
@@ -13,7 +13,7 @@ def test_log_output(tmp_path):
 
 import logging
 
-from src.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.logger import get_logger, log_exception
 
 
 def test_get_logger_returns_logger():

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 @pytest.fixture

--- a/tests/test_schedule_manager_run_pending.py
+++ b/tests/test_schedule_manager_run_pending.py
@@ -1,5 +1,5 @@
 import schedule
-from src.scheduling.schedule_manager import ScheduleManager
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 
 
 def test_run_pending_calls_schedule(monkeypatch):

--- a/tests/test_scraper_engine.py
+++ b/tests/test_scraper_engine.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
-from src.scraping.scraper_engine import ScraperEngine
-from src.scraping.content_extractor import ContentExtractor
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.scraper_engine import ScraperEngine
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 class DummyExtractor(ContentExtractor):

--- a/tests/test_scraping_components.py
+++ b/tests/test_scraping_components.py
@@ -4,9 +4,9 @@ from unittest.mock import patch
 import json
 
 
-from src.scraping.scraper_engine import ScraperEngine
-from src.scraping.content_extractor import ContentExtractor
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.scraper_engine import ScraperEngine
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 


### PR DESCRIPTION
## Summary
- update code imports to use `cinder_web_scraper` package
- refactor tests to import from `cinder_web_scraper`
- rewrite `ScheduleManager` for a clean SQLite backed implementation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: TypeError, RuntimeError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_686e4cceee708332aaf9e6b877dcee90