### PR TITLE
Fix imports to use cinder_web_scraper package

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ project_root/
 │   ├── schedules.db
 │   └── logs/
 ├── output/    # Scraped data is written here
-└── src/       # Application code
+└── cinder_web_scraper/       # Application code
 ```
 
 `data/` holds user configuration and log files while all scraped results are written to `output/`.
@@ -113,7 +113,7 @@ project_root/
 - `save_config(data, path=None)` – Save a configuration dictionary to ``path``. When ``path`` is omitted the data is written to `data/websites.json`.
 
 
-The `config_manager` module in `src/utils` provides convenience functions:
+The `config_manager` module in `cinder_web_scraper/utils` provides convenience functions:
 
 ```python
 from cinder_web_scraper.utils.config_manager import load_config, save_config
@@ -157,10 +157,10 @@ You will see a simple loop that executes a dummy job every few seconds.
 
 ### GUI application
 
-The GUI components live in `src/gui`. During development you can launch the (placeholder) main window with:
+The GUI components live in `cinder_web_scraper/gui`. During development you can launch the (placeholder) main window with:
 
 ```bash
-python -m src.gui.main_window
+python -m cinder_web_scraper.gui.main_window
 ```
 
 As features are implemented, this will provide buttons to manage websites, scheduling options, and view logs.
@@ -202,7 +202,7 @@ can experiment with the placeholder window using the following snippet:
 
 ```bash
 python - <<'PY'
-from src.gui.main_window import MainWindow
+from cinder_web_scraper.gui.main_window import MainWindow
 
 window = MainWindow()
 window.show()
@@ -235,10 +235,10 @@ path in your configuration file.
 
 ## Launching the GUI
 
-A basic Tkinter interface is provided in `src/gui`. To start the GUI, run:
+A basic Tkinter interface is provided in `cinder_web_scraper/gui`. To start the GUI, run:
 
 ```bash
-python -m src.gui.main_window
+python -m cinder_web_scraper.gui.main_window
 ```
 
 The GUI currently contains placeholder widgets but demonstrates how to integrate the scheduling system. The recent tasks added docstrings and type hints across these modules, making it easier to understand and extend the GUI code.

--- a/cinder_web_scraper/gui/main_window.py
+++ b/cinder_web_scraper/gui/main_window.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Callable, Optional
 
-from src.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.logger import get_logger, log_exception
 
 logger = get_logger(__name__)
 

--- a/cinder_web_scraper/gui/settings_panel.py
+++ b/cinder_web_scraper/gui/settings_panel.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any, Dict
 
-from src.utils import config_manager
+from cinder_web_scraper.utils import config_manager
 
 
 class SettingsPanel:

--- a/cinder_web_scraper/main.py
+++ b/cinder_web_scraper/main.py
@@ -2,7 +2,7 @@
 
 import time
 
-from src.scheduling.schedule_manager import ScheduleManager
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 
 
 def dummy_job() -> None:

--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -14,7 +14,7 @@ import os
 import sqlite3
 from typing import Callable, Dict
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 import schedule

--- a/cinder_web_scraper/scheduling/task_scheduler.py
+++ b/cinder_web_scraper/scheduling/task_scheduler.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Callable, Dict, List, Tuple
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class TaskScheduler:

--- a/cinder_web_scraper/scraping/content_extractor.py
+++ b/cinder_web_scraper/scraping/content_extractor.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ContentExtractor:
     """Parse HTML and return structured data or text from selected elements."""

--- a/cinder_web_scraper/scraping/output_manager.py
+++ b/cinder_web_scraper/scraping/output_manager.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class OutputManager:

--- a/cinder_web_scraper/scraping/scraper_engine.py
+++ b/cinder_web_scraper/scraping/scraper_engine.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 from .content_extractor import ContentExtractor
 from .output_manager import OutputManager
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ScraperEngine:
     """Download pages and extract data using provided helpers with retry support."""

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -5,16 +5,16 @@ This document provides an overview of the code base, contribution process and a 
 ## Code Structure
 
 ```
-src/
+cinder_web_scraper/
 ├── gui/                # Tkinter GUI components
 ├── scraping/           # Future scraping engine
 ├── scheduling/         # Task scheduling modules
 ├── utils/              # Utility helpers
 ```
 
-- **src/gui** – Placeholder classes for the Tkinter interface such as `MainWindow`, `WebsiteManager`, `SchedulerDialog` and `SettingsPanel`.
-- **src/scheduling** – Implements simple scheduling logic. `ScheduleManager` wraps the [`schedule`](https://pypi.org/project/schedule/) library and `TaskScheduler` provides an in-memory queue.
-- **src/utils** – Helper modules such as `config_manager` for reading/writing JSON config files.
+- **cinder_web_scraper/gui** – Placeholder classes for the Tkinter interface such as `MainWindow`, `WebsiteManager`, `SchedulerDialog` and `SettingsPanel`.
+- **cinder_web_scraper/scheduling** – Implements simple scheduling logic. `ScheduleManager` wraps the [`schedule`](https://pypi.org/project/schedule/) library and `TaskScheduler` provides an in-memory queue.
+- **cinder_web_scraper/utils** – Helper modules such as `config_manager` for reading/writing JSON config files.
 
 ## Contributing
 
@@ -27,19 +27,19 @@ We follow standard Python style with informative docstrings. Please keep commit 
 
 ## API Reference
 
-### `src.utils.config_manager`
+### `cinder_web_scraper.utils.config_manager`
 
 - `load_config(path)` – Return a configuration dictionary from `path`. If the file does not exist or is malformed, default settings are returned.
 - `save_config(data, path)` – Save a configuration dictionary to the given path. Returns `True` on success.
 
-### `src.scheduling.schedule_manager`
+### `cinder_web_scraper.scheduling.schedule_manager`
 
 - `add_task(name, func, interval)` – Schedule `func` to run every `interval` seconds. Returns the created job object.
 - `remove_task(name)` – Cancel a scheduled job by name. Returns `True` if removed.
 - `list_tasks()` – Return a mapping of task names to jobs.
 - `run_pending()` – Execute any tasks that are due to run.
 
-### `src.scheduling.task_scheduler`
+### `cinder_web_scraper.scheduling.task_scheduler`
 
 - `add_task(func, *args, **kwargs)` – Queue a callable with optional arguments.
 - `run_all()` – Execute queued callables in order and clear the queue.

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1,5 +1,5 @@
 import pytest
-from src.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
 
 
 def test_basic_html():

--- a/tests/test_file_and_logging_utils.py
+++ b/tests/test_file_and_logging_utils.py
@@ -1,6 +1,6 @@
 import builtins
-from src.utils.file_handler import FileHandler
-from src.utils.logger import get_logger
+from cinder_web_scraper.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.logger import get_logger
 
 
 def test_file_handler_methods_return_none(tmp_path):

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -1,5 +1,5 @@
 
-from src.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.file_handler import FileHandler
 
 
 def test_read_write(tmp_path):
@@ -15,7 +15,7 @@ import os
 
 import pytest
 
-from src.utils.file_handler import FileHandler
+from cinder_web_scraper.utils.file_handler import FileHandler
 
 
 @pytest.fixture()

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,7 +1,7 @@
-from src.gui.main_window import MainWindow
-from src.gui.scheduler_dialog import SchedulerDialog
-from src.gui.settings_panel import SettingsPanel
-from src.gui.website_manager import WebsiteManager
+from cinder_web_scraper.gui.main_window import MainWindow
+from cinder_web_scraper.gui.scheduler_dialog import SchedulerDialog
+from cinder_web_scraper.gui.settings_panel import SettingsPanel
+from cinder_web_scraper.gui.website_manager import WebsiteManager
 
 
 def test_main_window_show():

--- a/tests/test_gui_logic.py
+++ b/tests/test_gui_logic.py
@@ -1,14 +1,14 @@
 import os
 import pytest
 from unittest.mock import patch, MagicMock
-from src.gui.main_window import MainWindow
-from src.gui.scheduler_dialog import SchedulerDialog
-from src.gui.settings_panel import SettingsPanel
-from src.gui.website_manager import WebsiteManager
+from cinder_web_scraper.gui.main_window import MainWindow
+from cinder_web_scraper.gui.scheduler_dialog import SchedulerDialog
+from cinder_web_scraper.gui.settings_panel import SettingsPanel
+from cinder_web_scraper.gui.website_manager import WebsiteManager
 
 
 @pytest.mark.skipif(os.environ.get('CI') == 'true', reason='Skipping GUI tests in CI environment')
-@patch('src.gui.main_window.tk')
+@patch('cinder_web_scraper.gui.main_window.tk')
 def test_main_window_show_returns_none(mock_tk):
     # Mock tkinter to avoid display issues in CI
     mock_tk.Tk.return_value = MagicMock()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,5 @@
 
-from src.utils.logger import Logger
+from cinder_web_scraper.utils.logger import Logger
 
 
 def test_log_output(tmp_path):
@@ -13,7 +13,7 @@ def test_log_output(tmp_path):
 
 import logging
 
-from src.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.logger import get_logger, log_exception
 
 
 def test_get_logger_returns_logger():

--- a/tests/test_output_manager.py
+++ b/tests/test_output_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 @pytest.fixture

--- a/tests/test_schedule_manager_run_pending.py
+++ b/tests/test_schedule_manager_run_pending.py
@@ -1,5 +1,5 @@
 import schedule
-from src.scheduling.schedule_manager import ScheduleManager
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 
 
 def test_run_pending_calls_schedule(monkeypatch):

--- a/tests/test_scraper_engine.py
+++ b/tests/test_scraper_engine.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
-from src.scraping.scraper_engine import ScraperEngine
-from src.scraping.content_extractor import ContentExtractor
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.scraper_engine import ScraperEngine
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 class DummyExtractor(ContentExtractor):

--- a/tests/test_scraping_components.py
+++ b/tests/test_scraping_components.py
@@ -4,9 +4,9 @@ from unittest.mock import patch
 import json
 
 
-from src.scraping.scraper_engine import ScraperEngine
-from src.scraping.content_extractor import ContentExtractor
-from src.scraping.output_manager import OutputManager
+from cinder_web_scraper.scraping.scraper_engine import ScraperEngine
+from cinder_web_scraper.scraping.content_extractor import ContentExtractor
+from cinder_web_scraper.scraping.output_manager import OutputManager
 
 
 


### PR DESCRIPTION
## Summary
- update imports from `src` to `cinder_web_scraper`
- adjust README and developer guide examples to reference `cinder_web_scraper`
- update tests to import the package correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: SyntaxError in schedule_manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_686e4cec7ccc8332994e286e30a2e8c1