### PR TITLE
Fix schedule manager implementation

### DIFF
--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -1,143 +1,49 @@
-"""High-level interface for managing recurring tasks with persistence."""
-
-import os
-import sqlite3
-from typing import Callable, Dict, List, Optional
-
-import schedule
-
+"""SQLite-backed scheduler integration using the :mod:`schedule` library."""
 
 from __future__ import annotations
 
 import importlib
 import os
 import sqlite3
-from typing import Callable, Dict
+from typing import Callable, Dict, List, Optional
+
+import schedule
 
 from src.utils.logger import default_logger as logger
 
 
-import schedule
-
-
 class ScheduleManager:
-
-    """Manage scheduled jobs using the schedule package with SQLite persistence."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and ensure the SQLite table exists."""
-        self.jobs: Dict[str, schedule.Job] = {}
-        self.db_path = db_path
-        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
-        self.conn.row_factory = sqlite3.Row
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS schedules (name TEXT PRIMARY KEY, interval INTEGER)"
-        )
-        self.conn.commit()
-
-    # ------------------------------------------------------------------
-    # SQLite CRUD operations
-    # ------------------------------------------------------------------
-
-    def create_schedule(self, name: str, interval: int) -> None:
-        """Insert a schedule record."""
-        with self.conn:
-            self.conn.execute(
-                "INSERT INTO schedules (name, interval) VALUES (?, ?)",
-                (name, interval),
-            )
-
-    def get_schedule(self, name: str) -> Optional[Dict[str, int]]:
-        """Retrieve a schedule record by name."""
-        cur = self.conn.execute(
-            "SELECT name, interval FROM schedules WHERE name = ?",
-            (name,),
-        )
-        row = cur.fetchone()
-        if row:
-            return {"name": row["name"], "interval": row["interval"]}
-        return None
-
-    def update_schedule(self, name: str, interval: int) -> bool:
-        """Update the interval for a schedule."""
-        with self.conn:
-            cur = self.conn.execute(
-                "UPDATE schedules SET interval = ? WHERE name = ?",
-                (interval, name),
-            )
-            return cur.rowcount > 0
-
-    def delete_schedule(self, name: str) -> bool:
-        """Delete a schedule record."""
-        with self.conn:
-            cur = self.conn.execute(
-                "DELETE FROM schedules WHERE name = ?",
-                (name,),
-            )
-            return cur.rowcount > 0
-
-    def list_schedules(self) -> List[Dict[str, int]]:
-        """Return all schedules stored in the database."""
-        cur = self.conn.execute("SELECT name, interval FROM schedules")
-        return [
-            {"name": row["name"], "interval": row["interval"]}
-            for row in cur.fetchall()
-        ]
-
-    def __del__(self) -> None:
-        """Close the database connection when the manager is deleted."""
-        try:
-            self.conn.close()
-        except Exception:
-            pass
-
-    def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
-        job = schedule.every(interval).seconds.do(func)
-        self.jobs[name] = job
-
-        logger.log(f"Added task '{name}' to run every {interval} seconds")
-
-        with self.conn:
-            self.conn.execute(
-                "INSERT OR REPLACE INTO schedules (name, interval) VALUES (?, ?)",
-                (name, interval),
-            )
-
-        return job
-
-    def remove_task(self, name: str) -> bool:
-        """Remove a scheduled job by name and delete its record."""
-        job = self.jobs.pop(name, None)
-        if job:
-            schedule.cancel_job(job)
-            self.delete_schedule(name)
-
-    """Manage scheduled jobs using the schedule package and SQLite."""
+    """Manage scheduled tasks with persistent storage."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load tasks from ``db_path``.
+        """Initialize the manager and load any persisted tasks.
 
-        The SQLite database is created automatically if it does not exist.
+        Args:
+            db_path: Path to the SQLite database file.
         """
         self.db_path = db_path
         os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
-
-        self._conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
         self._init_db()
-
         self.jobs: Dict[str, schedule.Job] = {}
         self._load_tasks()
 
     # ------------------------------------------------------------------
-    # database handling
+    # Database setup and loading
     # ------------------------------------------------------------------
-
-    def _init_db(self) -e None:
-        """Create the tasks table if it doesn't exist."""
-        with self._conn:
-            self._conn.execute(
+    def _init_db(self) -> None:
+        """Create required tables if they do not exist."""
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schedules (
+                    name TEXT PRIMARY KEY,
+                    interval INTEGER NOT NULL
+                )
+                """
+            )
+            self.conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS tasks (
                     name TEXT PRIMARY KEY,
@@ -148,66 +54,131 @@ class ScheduleManager:
                 """
             )
 
-    def _load_tasks(self) -e None:
-        """Load all tasks from the database and schedule them."""
-        cursor = self._conn.execute(
+    def _load_tasks(self) -> None:
+        """Load tasks from the database and schedule them."""
+        cursor = self.conn.execute(
             "SELECT name, module, func_name, interval FROM tasks"
         )
-        for name, module, func_name, interval in cursor.fetchall():
+        for row in cursor.fetchall():
             try:
-                mod = importlib.import_module(module)
-                func = getattr(mod, func_name)
-            except Exception:
-                # Skip tasks that can't be imported
+                module = importlib.import_module(row["module"])
+                func = getattr(module, row["func_name"])
+            except Exception as exc:  # pragma: no cover - invalid entries
+                logger.error(f"Failed loading task {row['name']}: {exc}")
                 continue
-            job = schedule.every(interval).seconds.do(func)
-            self.jobs[name] = job
+            job = schedule.every(row["interval"]).seconds.do(func)
+            self.jobs[row["name"]] = job
 
-    def _persist_task(self, name: str, func: Callable, interval: int) -e None:
-        """Persist a task definition to the database."""
-        with self._conn:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
-                " VALUES (?, ?, ?, ?)",
+    # ------------------------------------------------------------------
+    # Schedule CRUD operations
+    # ------------------------------------------------------------------
+    def create_schedule(self, name: str, interval: int) -> None:
+        """Create a new schedule entry."""
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO schedules (name, interval) VALUES (?, ?)",
+                (name, interval),
+            )
+
+    def get_schedule(self, name: str) -> Optional[Dict[str, int]]:
+        """Return a schedule entry if it exists."""
+        cur = self.conn.execute(
+            "SELECT name, interval FROM schedules WHERE name = ?",
+            (name,),
+        )
+        row = cur.fetchone()
+        if row:
+            return {"name": row["name"], "interval": row["interval"]}
+        return None
+
+    def update_schedule(self, name: str, interval: int) -> bool:
+        """Update an existing schedule's interval."""
+        with self.conn:
+            cur = self.conn.execute(
+                "UPDATE schedules SET interval = ? WHERE name = ?",
+                (interval, name),
+            )
+            return cur.rowcount > 0
+
+    def delete_schedule(self, name: str) -> bool:
+        """Remove a schedule entry."""
+        with self.conn:
+            cur = self.conn.execute(
+                "DELETE FROM schedules WHERE name = ?",
+                (name,),
+            )
+            return cur.rowcount > 0
+
+    def list_schedules(self) -> List[Dict[str, int]]:
+        """Return all saved schedules."""
+        cur = self.conn.execute("SELECT name, interval FROM schedules")
+        return [
+            {"name": row["name"], "interval": row["interval"]}
+            for row in cur.fetchall()
+        ]
+
+    # ------------------------------------------------------------------
+    # Task management
+    # ------------------------------------------------------------------
+    def _persist_task(
+        self, name: str, func: Callable[..., None], interval: int
+    ) -> None:
+        """Persist task details to the database."""
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT OR REPLACE INTO tasks (name, module, func_name, interval)
+                VALUES (?, ?, ?, ?)
+                """,
                 (name, func.__module__, func.__name__, interval),
             )
 
-    def _delete_task(self, name: str) -e None:
-        """Remove a task from the database."""
-        with self._conn:
-            self._conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
+    def _delete_task(self, name: str) -> None:
+        """Delete a task record from the database."""
+        with self.conn:
+            self.conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
 
-    def add_task(self, name: str, func: Callable, interval: int) -e schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
+    def add_task(
+        self, name: str, func: Callable[..., None], interval: int
+    ) -> schedule.Job:
+        """Schedule ``func`` to run every ``interval`` seconds."""
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
         self._persist_task(name, func, interval)
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO schedules (name, interval) VALUES (?, ?)",
+                (name, interval),
+            )
+        logger.info(f"Added task '{name}' to run every {interval} seconds")
         return job
 
-    def remove_task(self, name: str) -e bool:
-        """Remove a scheduled job by name."""
+    def remove_task(self, name: str) -> bool:
+        """Remove a scheduled task."""
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
-            logger.log(f"Removed task '{name}'")
-
             self._delete_task(name)
-
-
+            self.delete_schedule(name)
+            logger.info(f"Removed task '{name}'")
             return True
-        logger.log(f"Attempted to remove unknown task '{name}'")
+        logger.warning(f"Attempted to remove unknown task '{name}'")
         return False
 
-    def list_tasks(self) -e Dict[str, schedule.Job]:
-        """Return a mapping of task names to jobs."""
-        logger.log("Listing scheduled tasks")
+    def list_tasks(self) -> Dict[str, schedule.Job]:
+        """Return a mapping of task names to scheduled jobs."""
         return dict(self.jobs)
 
-    def run_pending(self) -e None:
-        """Run all jobs that are scheduled to run."""
-        logger.log("Running pending scheduled tasks")
+    def run_pending(self) -> None:
+        """Run all pending scheduled jobs."""
         schedule.run_pending()
 
-    def close(self) -e None:
-        """Close the underlying SQLite connection."""
-        self._conn.close()
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self.conn.close()
+
+    def __del__(self) -> None:  # pragma: no cover - cleanup
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility shim mapping ``src`` package to :mod:`cinder_web_scraper`."""
+
+from importlib import import_module
+import sys
+
+_subpackages = {"gui", "scheduling", "scraping", "utils"}
+
+
+def __getattr__(name: str):
+    if name in _subpackages:
+        module = import_module(f"cinder_web_scraper.{name}")
+        sys.modules[f"src.{name}"] = module
+        return module
+    raise AttributeError(f"module 'src' has no attribute {name}")
+
+__all__ = list(_subpackages)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility wrapper for :mod:`cinder_web_scraper.gui`."""
+from importlib import import_module
+import sys
+
+_modules = [
+    "main_window",
+    "website_manager",
+    "scheduler_dialog",
+    "settings_panel",
+]
+
+for mod in _modules:
+    target = f"cinder_web_scraper.gui.{mod}"
+    sys.modules[f"src.gui.{mod}"] = import_module(target)
+
+__all__ = _modules

--- a/src/scheduling/__init__.py
+++ b/src/scheduling/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for :mod:`cinder_web_scraper.scheduling`."""
+from importlib import import_module
+import sys
+
+_modules = ["schedule_manager", "task_scheduler"]
+
+for mod in _modules:
+    target = f"cinder_web_scraper.scheduling.{mod}"
+    sys.modules[f"src.scheduling.{mod}"] = import_module(target)
+
+__all__ = _modules

--- a/src/scraping/__init__.py
+++ b/src/scraping/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for :mod:`cinder_web_scraper.scraping`."""
+from importlib import import_module
+import sys
+
+_modules = ["content_extractor", "output_manager", "scraper_engine"]
+
+for mod in _modules:
+    target = f"cinder_web_scraper.scraping.{mod}"
+    sys.modules[f"src.scraping.{mod}"] = import_module(target)
+
+__all__ = _modules

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for :mod:`cinder_web_scraper.utils`."""
+from importlib import import_module
+import sys
+
+_modules = ["config_manager", "file_handler", "logger"]
+
+for mod in _modules:
+    target = f"cinder_web_scraper.utils.{mod}"
+    sys.modules[f"src.utils.{mod}"] = import_module(target)
+
+__all__ = _modules


### PR DESCRIPTION
## Summary
- replace corrupted schedule_manager.py with a clean implementation
- persist tasks and schedules in SQLite
- add alias `src` package for backward compatible imports
- ensure CRUD operations and task scheduling work correctly

## Testing
- `pytest tests/test_schedule_manager.py tests/test_schedule_manager_run_pending.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4ced57d883328379ab727de0220e