### PR TITLE
Fix FileHandler error handling

### DIFF
--- a/cinder_web_scraper/utils/file_handler.py
+++ b/cinder_web_scraper/utils/file_handler.py
@@ -2,29 +2,22 @@
 
 from __future__ import annotations
 
-import os
-
-
 from pathlib import Path
 
 from .logger import default_logger as logger
 
 
 class FileHandler:
-
-    """Utility wrapper around standard file operations."""
-
     """High-level helper for reading and writing text files."""
 
-
     def read(self, path: str) -> str:
-        """Read a file and return its contents.
+        """Return the contents of ``path``.
 
         Args:
             path: Path to the file to read.
 
         Returns:
-            str: The contents of the file.
+            The contents of the file.
 
         Raises:
             FileNotFoundError: If ``path`` does not exist.
@@ -32,23 +25,19 @@ class FileHandler:
             OSError: For any other I/O related errors.
         """
         try:
-
             with open(path, "r", encoding="utf-8") as fp:
                 content = fp.read()
-            logger.log(f"Read file: {path}")
+            logger.info(f"Read file: {path}")
             return content
-        except OSError as exc:
-            logger.log(f"Failed to read file {path}: {exc}")
-            raise
-
-            with open(path, "r", encoding="utf-8") as fh:
-                return fh.read()
         except FileNotFoundError:
+            logger.error(f"File not found: {path}")
             raise
-        except PermissionError:
+        except PermissionError as exc:
+            logger.error(f"Permission denied reading {path}: {exc}")
             raise
         except OSError as exc:
-            raise OSError(f"Failed to read '{path}'") from exc
+            logger.error(f"Failed to read file {path}: {exc}")
+            raise
 
 
     def write(self, path: str, data: str) -> None:
@@ -65,20 +54,14 @@ class FileHandler:
             OSError: For any other I/O related errors.
         """
         try:
-
             Path(path).parent.mkdir(parents=True, exist_ok=True)
             with open(path, "w", encoding="utf-8") as fp:
                 fp.write(data)
-            logger.log(f"Wrote file: {path}")
-        except OSError as exc:
-            logger.log(f"Failed to write file {path}: {exc}")
-            raise
-
-            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-            with open(path, "w", encoding="utf-8") as fh:
-                fh.write(data)
-        except PermissionError:
+            logger.info(f"Wrote file: {path}")
+        except PermissionError as exc:
+            logger.error(f"Permission denied writing {path}: {exc}")
             raise
         except OSError as exc:
-            raise OSError(f"Failed to write to '{path}'") from exc
+            logger.error(f"Failed to write file {path}: {exc}")
+            raise
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,15 @@
+"""Compatibility layer exposing :mod:`cinder_web_scraper` as ``src``."""
+from importlib import import_module
+import sys
+
+_MODULES = ["utils", "gui", "scraping", "scheduling", "main"]
+
+__all__ = list(_MODULES)
+
+
+def __getattr__(name: str):
+    if name in _MODULES:
+        module = import_module(f"cinder_web_scraper.{name}")
+        sys.modules[f"src.{name}"] = module
+        return module
+    raise AttributeError(f"module 'src' has no attribute '{name}'")

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.gui import *

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.gui.main_window import *

--- a/src/gui/scheduler_dialog.py
+++ b/src/gui/scheduler_dialog.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.gui.scheduler_dialog import *

--- a/src/gui/settings_panel.py
+++ b/src/gui/settings_panel.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.gui.settings_panel import *

--- a/src/gui/website_manager.py
+++ b/src/gui/website_manager.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.gui.website_manager import *

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.main import *

--- a/src/scheduling/__init__.py
+++ b/src/scheduling/__init__.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scheduling import *

--- a/src/scheduling/schedule_manager.py
+++ b/src/scheduling/schedule_manager.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scheduling.schedule_manager import *

--- a/src/scheduling/task_scheduler.py
+++ b/src/scheduling/task_scheduler.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scheduling.task_scheduler import *

--- a/src/scraping/__init__.py
+++ b/src/scraping/__init__.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scraping import *

--- a/src/scraping/content_extractor.py
+++ b/src/scraping/content_extractor.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scraping.content_extractor import *

--- a/src/scraping/output_manager.py
+++ b/src/scraping/output_manager.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scraping.output_manager import *

--- a/src/scraping/scraper_engine.py
+++ b/src/scraping/scraper_engine.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.scraping.scraper_engine import *

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.utils import *

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.utils.config_manager import *

--- a/src/utils/file_handler.py
+++ b/src/utils/file_handler.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.utils.file_handler import *

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,1 @@
+from cinder_web_scraper.utils.logger import *

--- a/tests/test_file_and_logging_utils.py
+++ b/tests/test_file_and_logging_utils.py
@@ -3,10 +3,12 @@ from src.utils.file_handler import FileHandler
 from src.utils.logger import get_logger
 
 
-def test_file_handler_methods_return_none(tmp_path):
+def test_file_handler_read_write(tmp_path):
     fh = FileHandler()
-    assert fh.read(str(tmp_path / 'file.txt')) is None
-    assert fh.write(str(tmp_path / 'file.txt'), 'data') is None
+    file_path = tmp_path / 'file.txt'
+    fh.write(str(file_path), 'data')
+    assert file_path.exists()
+    assert fh.read(str(file_path)) == 'data'
 
 
 def test_logger_get_logger_returns_logger():


### PR DESCRIPTION
## Summary
- fix FileHandler.read/write error paths and logging
- add compatibility `src` package for legacy imports
- update tests to check for raised exceptions

## Testing
- `pytest tests/test_file_handler.py tests/test_file_and_logging_utils.py -q`
- `pytest -q` *(fails: SyntaxError in schedule_manager)*

------
https://chatgpt.com/codex/tasks/task_e_686e4ceeca788332b17cc9b2711f081f