### PR TITLE
Fix duplicate ScheduleManager and update imports

### DIFF
--- a/cinder_web_scraper/gui/main_window.py
+++ b/cinder_web_scraper/gui/main_window.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Callable, Optional
 
-from src.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.logger import get_logger, log_exception
 
 logger = get_logger(__name__)
 

--- a/cinder_web_scraper/gui/settings_panel.py
+++ b/cinder_web_scraper/gui/settings_panel.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from tkinter import messagebox, ttk
 from typing import Any, Dict
 
-from src.utils import config_manager
+from cinder_web_scraper.utils import config_manager
 
 
 class SettingsPanel:

--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -1,45 +1,84 @@
 """High-level interface for managing recurring tasks with persistence."""
 
+from __future__ import annotations
+
+import importlib
 import os
 import sqlite3
 from typing import Callable, Dict, List, Optional
 
 import schedule
 
-
-from __future__ import annotations
-
-import importlib
-import os
-import sqlite3
-from typing import Callable, Dict
-
-from src.utils.logger import default_logger as logger
-
-
-import schedule
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class ScheduleManager:
-
-    """Manage scheduled jobs using the schedule package with SQLite persistence."""
+    """Manage scheduled jobs using the schedule package and SQLite."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and ensure the SQLite table exists."""
-        self.jobs: Dict[str, schedule.Job] = {}
+        """Initialize the manager, create tables and load persisted tasks."""
         self.db_path = db_path
-        os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
+
         self.conn = sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS schedules (name TEXT PRIMARY KEY, interval INTEGER)"
+
+        self._init_db()
+        self.jobs: Dict[str, schedule.Job] = {}
+        self._load_tasks()
+
+    # ------------------------------------------------------------------
+    # database handling
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        """Create required tables if they don't exist."""
+        with self.conn:
+            self.conn.execute(
+                "CREATE TABLE IF NOT EXISTS schedules (name TEXT PRIMARY KEY, interval INTEGER)"
+            )
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    name TEXT PRIMARY KEY,
+                    module TEXT NOT NULL,
+                    func_name TEXT NOT NULL,
+                    interval INTEGER NOT NULL
+                )
+                """
+            )
+
+    def _load_tasks(self) -> None:
+        """Load all persisted tasks from the database."""
+        cursor = self.conn.execute(
+            "SELECT name, module, func_name, interval FROM tasks"
         )
-        self.conn.commit()
+        for name, module, func_name, interval in cursor.fetchall():
+            try:
+                mod = importlib.import_module(module)
+                func = getattr(mod, func_name)
+            except Exception:
+                # Skip tasks that can't be imported
+                continue
+            job = schedule.every(interval).seconds.do(func)
+            self.jobs[name] = job
+
+    def _persist_task(self, name: str, func: Callable, interval: int) -> None:
+        """Persist a task definition to the database."""
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
+                " VALUES (?, ?, ?, ?)",
+                (name, func.__module__, func.__name__, interval),
+            )
+
+    def _delete_task(self, name: str) -> None:
+        """Remove a task from the database."""
+        with self.conn:
+            self.conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
 
     # ------------------------------------------------------------------
-    # SQLite CRUD operations
+    # schedules table CRUD
     # ------------------------------------------------------------------
-
     def create_schedule(self, name: str, interval: int) -> None:
         """Insert a schedule record."""
         with self.conn:
@@ -85,129 +124,51 @@ class ScheduleManager:
             for row in cur.fetchall()
         ]
 
-    def __del__(self) -> None:
-        """Close the database connection when the manager is deleted."""
-        try:
-            self.conn.close()
-        except Exception:
-            pass
-
+    # ------------------------------------------------------------------
+    # task scheduling operations
+    # ------------------------------------------------------------------
     def add_task(self, name: str, func: Callable, interval: int) -> schedule.Job:
         """Add a job that runs every ``interval`` seconds and persist it."""
         job = schedule.every(interval).seconds.do(func)
         self.jobs[name] = job
-
         logger.log(f"Added task '{name}' to run every {interval} seconds")
 
+        self._persist_task(name, func, interval)
         with self.conn:
             self.conn.execute(
                 "INSERT OR REPLACE INTO schedules (name, interval) VALUES (?, ?)",
                 (name, interval),
             )
-
         return job
 
     def remove_task(self, name: str) -> bool:
-        """Remove a scheduled job by name and delete its record."""
-        job = self.jobs.pop(name, None)
-        if job:
-            schedule.cancel_job(job)
-            self.delete_schedule(name)
-
-    """Manage scheduled jobs using the schedule package and SQLite."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load tasks from ``db_path``.
-
-        The SQLite database is created automatically if it does not exist.
-        """
-        self.db_path = db_path
-        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
-
-        self._conn = sqlite3.connect(self.db_path)
-        self._init_db()
-
-        self.jobs: Dict[str, schedule.Job] = {}
-        self._load_tasks()
-
-    # ------------------------------------------------------------------
-    # database handling
-    # ------------------------------------------------------------------
-
-    def _init_db(self) -e None:
-        """Create the tasks table if it doesn't exist."""
-        with self._conn:
-            self._conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS tasks (
-                    name TEXT PRIMARY KEY,
-                    module TEXT NOT NULL,
-                    func_name TEXT NOT NULL,
-                    interval INTEGER NOT NULL
-                )
-                """
-            )
-
-    def _load_tasks(self) -e None:
-        """Load all tasks from the database and schedule them."""
-        cursor = self._conn.execute(
-            "SELECT name, module, func_name, interval FROM tasks"
-        )
-        for name, module, func_name, interval in cursor.fetchall():
-            try:
-                mod = importlib.import_module(module)
-                func = getattr(mod, func_name)
-            except Exception:
-                # Skip tasks that can't be imported
-                continue
-            job = schedule.every(interval).seconds.do(func)
-            self.jobs[name] = job
-
-    def _persist_task(self, name: str, func: Callable, interval: int) -e None:
-        """Persist a task definition to the database."""
-        with self._conn:
-            self._conn.execute(
-                "INSERT OR REPLACE INTO tasks (name, module, func_name, interval)"
-                " VALUES (?, ?, ?, ?)",
-                (name, func.__module__, func.__name__, interval),
-            )
-
-    def _delete_task(self, name: str) -e None:
-        """Remove a task from the database."""
-        with self._conn:
-            self._conn.execute("DELETE FROM tasks WHERE name = ?", (name,))
-
-    def add_task(self, name: str, func: Callable, interval: int) -e schedule.Job:
-        """Add a job that runs every ``interval`` seconds and persist it."""
-        job = schedule.every(interval).seconds.do(func)
-        self.jobs[name] = job
-        self._persist_task(name, func, interval)
-        return job
-
-    def remove_task(self, name: str) -e bool:
         """Remove a scheduled job by name."""
         job = self.jobs.pop(name, None)
         if job:
             schedule.cancel_job(job)
             logger.log(f"Removed task '{name}'")
-
             self._delete_task(name)
-
-
+            self.delete_schedule(name)
             return True
         logger.log(f"Attempted to remove unknown task '{name}'")
         return False
 
-    def list_tasks(self) -e Dict[str, schedule.Job]:
+    def list_tasks(self) -> Dict[str, schedule.Job]:
         """Return a mapping of task names to jobs."""
         logger.log("Listing scheduled tasks")
         return dict(self.jobs)
 
-    def run_pending(self) -e None:
+    def run_pending(self) -> None:
         """Run all jobs that are scheduled to run."""
         logger.log("Running pending scheduled tasks")
         schedule.run_pending()
 
-    def close(self) -e None:
+    def close(self) -> None:
         """Close the underlying SQLite connection."""
-        self._conn.close()
+        self.conn.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/cinder_web_scraper/scheduling/task_scheduler.py
+++ b/cinder_web_scraper/scheduling/task_scheduler.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Callable, Dict, List, Tuple
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class TaskScheduler:

--- a/cinder_web_scraper/scraping/content_extractor.py
+++ b/cinder_web_scraper/scraping/content_extractor.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ContentExtractor:
     """Parse HTML and return structured data or text from selected elements."""

--- a/cinder_web_scraper/scraping/output_manager.py
+++ b/cinder_web_scraper/scraping/output_manager.py
@@ -8,7 +8,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class OutputManager:

--- a/cinder_web_scraper/scraping/scraper_engine.py
+++ b/cinder_web_scraper/scraping/scraper_engine.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 from .content_extractor import ContentExtractor
 from .output_manager import OutputManager
 
-from src.utils.logger import default_logger as logger
+from cinder_web_scraper.utils.logger import default_logger as logger
 
 class ScraperEngine:
     """Download pages and extract data using provided helpers with retry support."""


### PR DESCRIPTION
## Summary
- simplify `ScheduleManager` with single constructor and task loading
- use `cinder_web_scraper.utils.logger` across modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_686e4cd63fb08332b4535d3144afca14