### PR TITLE
Add repository update helper and GUI action

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ PY
 
 Future releases will bundle a launcher script that opens the GUI directly.
 
+## Updating the Repository
+
+The GUI offers a convenient way to pull the latest changes. Choose
+**Tools → Update Repo** from the menu and confirm the prompt. The application
+will run ``git pull`` and notify you whether the update succeeded.
+
 ## Troubleshooting
 
 If the application fails to start or tests do not run, try the following:

--- a/cinder_web_scraper/gui/main_window.py
+++ b/cinder_web_scraper/gui/main_window.py
@@ -7,6 +7,7 @@ from tkinter import messagebox, ttk
 from typing import Callable, Optional
 
 from cinder_web_scraper.utils.logger import get_logger, log_exception
+from cinder_web_scraper.utils.repo_updater import update_repo
 
 logger = get_logger(__name__)
 
@@ -51,7 +52,9 @@ class MainWindow:
         file_menu.add_command(label="Exit", command=self.root.quit)
         menubar.add_cascade(label="File", menu=file_menu)
         menubar.add_cascade(label="Edit", menu=tk.Menu(menubar, tearoff=0))
-        menubar.add_cascade(label="Tools", menu=tk.Menu(menubar, tearoff=0))
+        tools_menu = tk.Menu(menubar, tearoff=0)
+        tools_menu.add_command(label="Update Repo", command=self._on_update_repo)
+        menubar.add_cascade(label="Tools", menu=tools_menu)
         menubar.add_cascade(label="Help", menu=tk.Menu(menubar, tearoff=0))
         self.root.config(menu=menubar)
 
@@ -135,6 +138,19 @@ class MainWindow:
     def _on_settings(self) -> None:
         if self.on_settings:
             self.on_settings()
+
+    def _on_update_repo(self) -> None:
+        """Pull the latest changes from the git repository."""
+
+        if not messagebox.askyesno(
+            "Update Repository", "Pull latest changes from the repository?"
+        ):
+            return
+
+        if update_repo():
+            messagebox.showinfo("Update", "Repository updated successfully")
+        else:
+            messagebox.showerror("Update", "Failed to update repository")
 
     def show(self) -> None:
         """Display the main window with basic error handling."""

--- a/cinder_web_scraper/utils/__init__.py
+++ b/cinder_web_scraper/utils/__init__.py
@@ -1,0 +1,15 @@
+"""Utility helper modules for the application."""
+
+from .config_manager import load_config, save_config
+from .file_handler import FileHandler
+from .logger import get_logger, log_exception
+from .repo_updater import update_repo
+
+__all__ = [
+    "load_config",
+    "save_config",
+    "FileHandler",
+    "get_logger",
+    "log_exception",
+    "update_repo",
+]

--- a/cinder_web_scraper/utils/file_handler.py
+++ b/cinder_web_scraper/utils/file_handler.py
@@ -67,12 +67,7 @@ class FileHandler:
         except PermissionError as exc:
             logger.error(f"Permission denied writing {path}: {exc}")
             raise
-        except OSError as exc:
-            logger.error(f"Failed to write file {path}: {exc}")
-
-            logger.log(f"Wrote file: {path}")
         except (PermissionError, OSError) as exc:
             logger.log(f"Failed to write file {path}: {exc}")
-
             raise
 

--- a/cinder_web_scraper/utils/repo_updater.py
+++ b/cinder_web_scraper/utils/repo_updater.py
@@ -1,0 +1,27 @@
+"""Utilities for updating the local git repository."""
+
+from __future__ import annotations
+
+import subprocess
+
+from .logger import default_logger as logger
+
+
+def update_repo() -> bool:
+    """Run ``git pull`` to update the repository.
+
+    Returns:
+        ``True`` if the command succeeded, otherwise ``False``.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "pull"], capture_output=True, text=True, check=False
+        )
+        if result.returncode == 0:
+            logger.info("Repository updated successfully")
+            return True
+        logger.error(f"Failed to update repository: {result.stderr.strip()}")
+        return False
+    except Exception as exc:  # pragma: no cover - unexpected subprocess errors
+        logger.error(f"Error running git pull: {exc}")
+        return False

--- a/tests/test_repo_updater.py
+++ b/tests/test_repo_updater.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock, patch
+
+from cinder_web_scraper.utils.repo_updater import update_repo
+
+
+@patch("cinder_web_scraper.utils.repo_updater.subprocess.run")
+def test_update_repo_success(mock_run):
+    mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    assert update_repo() is True
+    mock_run.assert_called_with(["git", "pull"], capture_output=True, text=True, check=False)
+
+
+@patch("cinder_web_scraper.utils.repo_updater.subprocess.run")
+def test_update_repo_failure(mock_run):
+    mock_run.return_value = MagicMock(returncode=1, stderr="error", stdout="")
+    assert update_repo() is False
+
+
+@patch("cinder_web_scraper.utils.repo_updater.subprocess.run", side_effect=OSError)
+def test_update_repo_exception(mock_run):
+    assert update_repo() is False


### PR DESCRIPTION
## Summary
- implement `update_repo` utility that runs `git pull`
- expose helper in utils package
- fix FileHandler exception handling
- add menu option in GUI to update repository with confirmation
- document repo update feature
- add unit tests for `update_repo`

## Testing
- `pip install schedule requests beautifulsoup4`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fddb47c3083329497981cc226bef7