### PR TITLE
Mock scraper tests

### DIFF
--- a/cinder_web_scraper/utils/file_handler.py
+++ b/cinder_web_scraper/utils/file_handler.py
@@ -69,10 +69,5 @@ class FileHandler:
             raise
         except OSError as exc:
             logger.error(f"Failed to write file {path}: {exc}")
-
-            logger.log(f"Wrote file: {path}")
-        except (PermissionError, OSError) as exc:
-            logger.log(f"Failed to write file {path}: {exc}")
-
             raise
 

--- a/tests/test_scraper_engine.py
+++ b/tests/test_scraper_engine.py
@@ -36,7 +36,7 @@ def test_scrape_success(tmp_path):
     response.status_code = 200
     response._content = html.encode()
 
-    with patch.object(engine.session, "get", return_value=response) as mock_get:
+    with patch("requests.Session.get", return_value=response) as mock_get:
         data = engine.scrape("http://example.com", str(tmp_path / "out.json"))
 
     assert mock_get.called
@@ -49,8 +49,8 @@ def test_scrape_retries(tmp_path):
     output = DummyOutput()
     engine = ScraperEngine(extractor, output, {"delay": 0, "retries": 2})
 
-    with patch.object(
-        engine.session, "get", side_effect=requests.RequestException
+    with patch(
+        "requests.Session.get", side_effect=requests.RequestException
     ) as mock_get:
         data = engine.scrape("http://example.com", str(tmp_path / "out.json"))
 
@@ -63,23 +63,47 @@ def test_scrape_retries(tmp_path):
 def test_scraper_engine_scrape_returns_content():
     """Test that scraper engine can successfully fetch content."""
     engine = ScraperEngine(delay=0)
-    result = engine.scrape('http://example.com')
+    html = (
+        "<html><head><title>Example Domain</title></head>"
+        "<body>Example Domain</body></html>"
+    )
+    response = requests.Response()
+    response.status_code = 200
+    response._content = html.encode()
+
+    with patch("requests.Session.get", return_value=response) as mock_get:
+        result = engine.scrape("http://example.com")
     # Should return HTML content, not None, for a valid URL
     assert result is not None
     assert isinstance(result, str)
-    assert 'Example Domain' in result  # example.com contains this text
+    assert "Example Domain" in result  # example.com contains this text
+    assert mock_get.called
 
 
 def test_scraper_engine_scrape_returns_none_for_invalid_url():
     """Test that scraper engine returns None for invalid URLs."""
     engine = ScraperEngine(delay=0)
-    result = engine.scrape('http://invalid-url-that-does-not-exist-12345.com')
+    with patch(
+        "requests.Session.get", side_effect=requests.RequestException
+    ) as mock_get:
+        result = engine.scrape("http://invalid-url-that-does-not-exist-12345.com")
     # Should return None for invalid URLs
     assert result is None
+    assert mock_get.called
 
 
 def test_scraper_engine_scrape_working_url():
     engine = ScraperEngine(delay=0)
-    content = engine.scrape('http://example.com')
-    assert '<html>' in content 
-    assert '<title>Example Domain</title>' in content
+    html = (
+        "<html><head><title>Example Domain</title></head>"
+        "<body>Example Domain</body></html>"
+    )
+    response = requests.Response()
+    response.status_code = 200
+    response._content = html.encode()
+
+    with patch("requests.Session.get", return_value=response) as mock_get:
+        content = engine.scrape("http://example.com")
+    assert "<html>" in content
+    assert "<title>Example Domain</title>" in content
+    assert mock_get.called


### PR DESCRIPTION
## Summary
- mock `requests.Session.get` in scraper engine tests
- update tests with dummy HTML to ensure offline execution
- fix FileHandler.write to re-raise `OSError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fddd51c18833292d36b7ce2aabe72