### PR TITLE
Fix src compatibility layer

### DIFF
--- a/cinder_web_scraper/utils/file_handler.py
+++ b/cinder_web_scraper/utils/file_handler.py
@@ -69,10 +69,5 @@ class FileHandler:
             raise
         except OSError as exc:
             logger.error(f"Failed to write file {path}: {exc}")
-
-            logger.log(f"Wrote file: {path}")
-        except (PermissionError, OSError) as exc:
-            logger.log(f"Failed to write file {path}: {exc}")
-
             raise
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,28 +1,20 @@
-
 """Compatibility layer exposing :mod:`cinder_web_scraper` as ``src``."""
+
 from importlib import import_module
 import sys
+from types import ModuleType
 
 _MODULES = ["utils", "gui", "scraping", "scheduling", "main"]
 
 __all__ = list(_MODULES)
 
+# Preload submodules to allow ``import src.utils`` style imports
+for _mod in _MODULES:
+    sys.modules[f"src.{_mod}"] = import_module(f"cinder_web_scraper.{_mod}")
 
-def __getattr__(name: str):
+
+def __getattr__(name: str) -> ModuleType:
+    """Return the mapped submodule if present."""
     if name in _MODULES:
-        module = import_module(f"cinder_web_scraper.{name}")
-        sys.modules[f"src.{name}"] = module
-        return module
+        return sys.modules[f"src.{name}"]
     raise AttributeError(f"module 'src' has no attribute '{name}'")
-
-"""Compatibility layer mapping the legacy ``src`` namespace to ``cinder_web_scraper``."""
-
-import sys
-from importlib import import_module
-
-PACKAGE = "cinder_web_scraper"
-
-# Map submodules to maintain backward compatibility with the old ``src``
-# namespace. Import ``utils`` first as other modules depend on it.
-for _mod in ["utils", "scheduling", "scraping", "gui", "main"]:
-    sys.modules[f"src.{_mod}"] = import_module(f"{PACKAGE}.{_mod}")


### PR DESCRIPTION
## Summary
- map submodules to maintain legacy `src` namespace
- clean up stray newline and remove duplicate code
- simplify `FileHandler.write` error handling

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fddace1548332903a3ad74ce7801d