### PR TITLE
Fix pyproject package find section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ dev = [
     "pytest==8.4.0",
 ]
 
-[tool.setuptools.packages.find]where = ["."]
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
## Summary
- fix `pyproject.toml` package section formatting

## Testing
- `pytest -q`
- `pytest tests/test_file_handler.py::test_write_invalid_path -vv`

------
https://chatgpt.com/codex/tasks/task_e_686fddc8ccf883328f3ee569438b2a9c