### PR TITLE
Cleanup logger in main.py

### DIFF
--- a/cinder_web_scraper/main.py
+++ b/cinder_web_scraper/main.py
@@ -7,7 +7,6 @@ import traceback
 
 from cinder_web_scraper.gui.main_window import MainWindow
 from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
-from cinder_web_scraper.utils.logger import default_logger as logger
 from cinder_web_scraper.utils.logger import get_logger
 
 
@@ -26,15 +25,15 @@ def parse_arguments() -> argparse.Namespace:
 def run_cli() -> None:
     manager = ScheduleManager()
     if not manager.list_tasks():
-        manager.add_task("dummy", lambda: logger.log("Dummy job executed"), 5)
+        manager.add_task("dummy", lambda: logger.info("Dummy job executed"), 5)
 
-    logger.log("Scheduler started. Press Ctrl+C to exit.")
+    logger.info("Scheduler started. Press Ctrl+C to exit.")
     try:
         while True:
             manager.run_pending()
             time.sleep(1)
     except KeyboardInterrupt:
-        logger.log("Scheduler stopped.")
+        logger.info("Scheduler stopped.")
         print("\nScheduler stopped.")
     except Exception as exc:  # pragma: no cover
         print("An unexpected error occurred. See log for details.")

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import traceback
 
 from cinder_web_scraper.gui.main_window import MainWindow
 from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
-from cinder_web_scraper.utils.logger import default_logger as logger
 from cinder_web_scraper.utils.logger import get_logger
 
 
@@ -26,15 +25,15 @@ def parse_arguments() -> argparse.Namespace:
 def run_cli() -> None:
     manager = ScheduleManager()
     if not manager.list_tasks():
-        manager.add_task("dummy", lambda: logger.log("Dummy job executed"), 5)
+        manager.add_task("dummy", lambda: logger.info("Dummy job executed"), 5)
 
-    logger.log("Scheduler started. Press Ctrl+C to exit.")
+    logger.info("Scheduler started. Press Ctrl+C to exit.")
     try:
         while True:
             manager.run_pending()
             time.sleep(1)
     except KeyboardInterrupt:
-        logger.log("Scheduler stopped.")
+        logger.info("Scheduler stopped.")
         print("\nScheduler stopped.")
     except Exception as exc:  # pragma: no cover
         print("An unexpected error occurred. See log for details.")


### PR DESCRIPTION
## Summary
- remove the unused `default_logger` import in both `main.py` files
- switch to `logger.info()` calls so logging still works

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687114a36638833294131728c5864d73