### PR TITLE
Fix ScheduleManager import checks and restore module

### DIFF
--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -1,6 +1,4 @@
-
 """High-level interface for managing recurring tasks with SQLite persistence."""
-
 
 from __future__ import annotations
 
@@ -15,28 +13,10 @@ from cinder_web_scraper.utils.logger import default_logger as logger
 
 
 class ScheduleManager:
-
-    """Manage scheduled jobs using the :mod:`schedule` package with SQLite persistence."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load any stored tasks."""
-
-
     """Manage scheduled jobs using the schedule package and SQLite."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
         """Initialize the manager and load stored tasks."""
-
-    """Manage scheduled jobs using the :mod:`schedule` package with persistence."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load any stored tasks.
-
-        Args:
-            db_path: Location of the SQLite database file.
-        """
-
-
         self.db_path = db_path
         os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
 
@@ -82,12 +62,8 @@ class ScheduleManager:
             try:
                 mod = importlib.import_module(module)
                 func = getattr(mod, func_name)
-
             except Exception:
                 # Skip tasks that cannot be imported
-
-            except Exception:  # pragma: no cover - invalid modules ignored
-
                 continue
             job = schedule.every(interval).seconds.do(func)
             self.jobs[name] = job

--- a/tests/test_schedule_manager.py
+++ b/tests/test_schedule_manager.py
@@ -2,7 +2,7 @@ import schedule
 import pytest
 try:
     from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
-except Exception as exc:  # pragma: no cover - skip if module fails to import
+except ImportError as exc:  # pragma: no cover - skip if module missing
     pytest.skip(f"ScheduleManager unavailable: {exc}", allow_module_level=True)
 from tests.dummy_module import dummy_task
 

--- a/tests/test_schedule_manager_run_pending.py
+++ b/tests/test_schedule_manager_run_pending.py
@@ -2,7 +2,7 @@ import schedule
 import pytest
 try:
     from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
-except Exception as exc:  # pragma: no cover - skip if module fails to import
+except ImportError as exc:  # pragma: no cover - skip if module missing
     pytest.skip(f"ScheduleManager unavailable: {exc}", allow_module_level=True)
 
 


### PR DESCRIPTION
## Summary
- restore `ScheduleManager` to a working implementation
- narrow the import try/except in schedule manager tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687114a984588332850ced1c587f7a1c