### PR TITLE
Fix __init__ and error handling in ScheduleManager

### DIFF
--- a/cinder_web_scraper/scheduling/schedule_manager.py
+++ b/cinder_web_scraper/scheduling/schedule_manager.py
@@ -19,17 +19,6 @@ class ScheduleManager:
     """Manage scheduled jobs using the :mod:`schedule` package with SQLite persistence."""
 
     def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load any stored tasks."""
-
-
-    """Manage scheduled jobs using the schedule package and SQLite."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
-        """Initialize the manager and load stored tasks."""
-
-    """Manage scheduled jobs using the :mod:`schedule` package with persistence."""
-
-    def __init__(self, db_path: str = "data/schedules.db") -> None:
         """Initialize the manager and load any stored tasks.
 
         Args:
@@ -82,13 +71,12 @@ class ScheduleManager:
             try:
                 mod = importlib.import_module(module)
                 func = getattr(mod, func_name)
-
-            except Exception:
-                # Skip tasks that cannot be imported
-
-            except Exception:  # pragma: no cover - invalid modules ignored
-
+            except Exception as exc:  # pragma: no cover - invalid modules ignored
+                logger.error(
+                    f"Failed to import task '{name}' from {module}:{func_name}: {exc}"
+                )
                 continue
+
             job = schedule.every(interval).seconds.do(func)
             self.jobs[name] = job
 


### PR DESCRIPTION
## Summary
- fix duplicated constructors in `schedule_manager.py`
- handle task import errors with a single `except` block

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687114a8bc408332b267e63ee9e05887