### PR TITLE
Remove unused os import

### DIFF
--- a/cinder_web_scraper/scraping/output_manager.py
+++ b/cinder_web_scraper/scraping/output_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
## Summary
- clean up unused import from output manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713dcf6c088332acd35ed4ec718a75