### PR TITLE
Fix setup script conditional file creation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,8 +8,14 @@ pip install -r requirements.txt
 mkdir -p data/logs output
 
 # Create empty config files if missing
-: > data/websites.json
-: > data/schedules.db
+if [ ! -f data/websites.json ]; then
+  touch data/websites.json
+fi
+
+if [ ! -f data/schedules.db ]; then
+  touch data/schedules.db
+fi
+
 if [ ! -f data/config.json ]; then
-  : > data/config.json
+  touch data/config.json
 fi


### PR DESCRIPTION
## Summary
- update `setup.sh` to only create config files if they don't already exist

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713dd0a800833292c13a09f93d9e5b