### PR TITLE
Add docstring for settings _save

### DIFF
--- a/cinder_web_scraper/gui/settings_panel.py
+++ b/cinder_web_scraper/gui/settings_panel.py
@@ -53,6 +53,13 @@ class SettingsPanel:
         )
 
     def _save(self) -> None:
+        """Save settings and close the panel.
+
+        The current logging option is persisted to ``data/config.json`` using
+        ``config_manager``. A message box notifies the user whether the save was
+        successful and the settings window is closed afterwards.
+        """
+
         assert self.logging_var is not None
         self.settings["logging"] = self.logging_var.get()
         config = config_manager.load_config("data/config.json")


### PR DESCRIPTION
## Summary
- document the `_save` method in `SettingsPanel`

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e068a3c8332aca347a020688524