### PR TITLE
Format long lines and add flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203,W503

--- a/cinder_web_scraper/gui/main_window.py
+++ b/cinder_web_scraper/gui/main_window.py
@@ -49,10 +49,26 @@ class MainWindow:
         self.root.config(menu=menubar)
 
         toolbar = ttk.Frame(self.root)
-        ttk.Button(toolbar, text="Add Site", command=self._on_manage_sites).pack(side=tk.LEFT, padx=2, pady=2)
-        ttk.Button(toolbar, text="Start Scraping", command=self._start_scraping).pack(side=tk.LEFT, padx=2, pady=2)
-        ttk.Button(toolbar, text="Settings", command=self._on_settings).pack(side=tk.LEFT, padx=2, pady=2)
-        ttk.Button(toolbar, text="Update", command=self._update_app).pack(side=tk.LEFT, padx=2, pady=2)
+        ttk.Button(
+            toolbar,
+            text="Add Site",
+            command=self._on_manage_sites,
+        ).pack(side=tk.LEFT, padx=2, pady=2)
+        ttk.Button(
+            toolbar,
+            text="Start Scraping",
+            command=self._start_scraping,
+        ).pack(side=tk.LEFT, padx=2, pady=2)
+        ttk.Button(
+            toolbar,
+            text="Settings",
+            command=self._on_settings,
+        ).pack(side=tk.LEFT, padx=2, pady=2)
+        ttk.Button(
+            toolbar,
+            text="Update",
+            command=self._update_app,
+        ).pack(side=tk.LEFT, padx=2, pady=2)
         toolbar.pack(fill=tk.X)
 
         list_frame = ttk.Frame(self.root)
@@ -69,7 +85,11 @@ class MainWindow:
         ttk.Button(actions, text="Start", command=self._start_scraping).pack(side=tk.LEFT, padx=5)
         ttk.Button(actions, text="Stop", command=self._stop_scraping).pack(side=tk.LEFT, padx=5)
         ttk.Button(actions, text="Schedule", command=self._on_schedule).pack(side=tk.LEFT, padx=5)
-        ttk.Button(actions, text="Configure", command=self._on_manage_sites).pack(side=tk.LEFT, padx=5)
+        ttk.Button(
+            actions,
+            text="Configure",
+            command=self._on_manage_sites,
+        ).pack(side=tk.LEFT, padx=5)
         actions.pack(pady=5)
 
         status = ttk.Label(self.root, textvariable=self.status_var, relief=tk.SUNKEN, anchor=tk.W)
@@ -115,4 +135,3 @@ class MainWindow:
                 "An unexpected error occurred. See log for details.",
             )
             log_exception(logger, "Unhandled exception in GUI", exc)
-

--- a/tests/test_repo_updater.py
+++ b/tests/test_repo_updater.py
@@ -8,12 +8,14 @@ from cinder_web_scraper.utils.updater import update_repo
 def test_update_repo_success(mock_run):
     mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
     assert update_repo() is True
-    mock_run.assert_called_with(["git", "pull", "origin"], check=True, capture_output=True, text=True)
+    mock_run.assert_called_with(
+        ["git", "pull", "origin"], check=True, capture_output=True, text=True
+    )
 
 
 @patch("cinder_web_scraper.utils.updater.subprocess.run")
 def test_update_repo_failure(mock_run):
-    mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "pull"]) 
+    mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "pull"])
     assert update_repo() is False
 
 


### PR DESCRIPTION
## Summary
- limit lines to 100 characters
- wrap long buttons in GUI code
- shorten a test assertion
- add `.flake8` with max line length 100

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713dd80aa88332b3f6be8b1546737d