### PR TITLE
Add CLI argument tests

### DIFF
--- a/cinder_web_scraper/main.py
+++ b/cinder_web_scraper/main.py
@@ -10,13 +10,23 @@ from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 from cinder_web_scraper.utils.logger import default_logger as logger
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Args:
+        args: Optional list of arguments to parse. If ``None``, ``sys.argv`` is
+            used automatically.
+
+    Returns:
+        Parsed arguments namespace.
+    """
+
     parser = argparse.ArgumentParser(description="Cinder's Web Scraper")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--gui", action="store_true", help="Launch in GUI mode")
     group.add_argument("--cli", action="store_true", help="Launch in CLI mode")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def run_cli() -> None:

--- a/main.py
+++ b/main.py
@@ -10,13 +10,23 @@ from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
 from cinder_web_scraper.utils.logger import default_logger as logger
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Args:
+        args: Optional list of command line arguments to parse. If ``None``,
+            ``sys.argv`` values are used.
+
+    Returns:
+        Parsed argument namespace.
+    """
+
     parser = argparse.ArgumentParser(description="Cinder's Web Scraper")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--gui", action="store_true", help="Launch in GUI mode")
     group.add_argument("--cli", action="store_true", help="Launch in CLI mode")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def run_cli() -> None:

--- a/tests/test_cli_arguments.py
+++ b/tests/test_cli_arguments.py
@@ -1,0 +1,11 @@
+from cinder_web_scraper.main import parse_arguments
+
+
+def test_cli_default():
+    args = parse_arguments([])
+    assert not args.cli and not args.gui
+
+
+def test_cli_flag():
+    args = parse_arguments(['--cli'])
+    assert args.cli is True


### PR DESCRIPTION
## Summary
- allow passing a list of args to `parse_arguments`
- test CLI flags in new `tests/test_cli_arguments.py`

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713e024aec833281ceaa417d1a46e0