### PR TITLE
Fix README badge and clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cinder's Web Scraper
 
-[![CI](https://github.com/OWNER/Cinder-s-Webscraper/actions/workflows/python.yml/badge.svg)](https://github.com/OWNER/Cinder-s-Webscraper/actions/workflows/python.yml)
+[![CI](https://github.com/c1nderscript/Cinder-s-Webscraper/actions/workflows/python.yml/badge.svg)](https://github.com/c1nderscript/Cinder-s-Webscraper/actions/workflows/python.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue)](#license)
 
 ## Project Overview
@@ -46,8 +46,8 @@ compatible Python interpreter.
 2. Clone this repository:
 
    ```bash
-   git clone https://github.com/your-user/cinder-webscraper.git
-   cd cinder-webscraper
+   git clone https://github.com/c1nderscript/Cinder-s-Webscraper.git
+   cd Cinder-s-Webscraper
    ```
 
 3. (Optional) Create and activate a virtual environment:


### PR DESCRIPTION
## Summary
- update workflow badge URL with actual repo
- update clone instructions with real repo path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713df89b6483328e7ce24b9348ce5d