### PR TITLE
Fix import paths in GUI docs

### DIFF
--- a/GUI_Launch_Process.md
+++ b/GUI_Launch_Process.md
@@ -182,8 +182,8 @@ from pathlib import Path
 
 # Import application modules
 from gui.main_window import MainWindow
-from core.config_manager import ConfigManager, ConfigError
-from core.schedule_manager import ScheduleManager, ScheduleError
+from cinder_web_scraper.utils.config_manager import ConfigManager, ConfigError
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager, ScheduleError
 from cli.cli_interface import CLIInterface
 
 # Configure logging


### PR DESCRIPTION
## Summary
- update imports in `GUI_Launch_Process.md` to use `cinder_web_scraper` modules

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713de9d06483329a7ae61d427c32b3