### PR TITLE
Remove unused imports flagged by ruff

### DIFF
--- a/cinder_web_scraper/main.py
+++ b/cinder_web_scraper/main.py
@@ -32,7 +32,7 @@ def run_cli() -> None:
     except KeyboardInterrupt:
         logger.log("Scheduler stopped.")
         print("\nScheduler stopped.")
-    except Exception as exc:  # pragma: no cover
+    except Exception:  # pragma: no cover
         print("An unexpected error occurred. See log for details.")
         logger.error("Unhandled exception in CLI")
         logger.error(traceback.format_exc())

--- a/cinder_web_scraper/scraping/output_manager.py
+++ b/cinder_web_scraper/scraping/output_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 from pathlib import Path
 from typing import Any
 

--- a/cinder_web_scraper/scraping/scraper_engine.py
+++ b/cinder_web_scraper/scraping/scraper_engine.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import time
 from typing import Any, Dict, Optional
 

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def run_cli() -> None:
     except KeyboardInterrupt:
         logger.log("Scheduler stopped.")
         print("\nScheduler stopped.")
-    except Exception as exc:  # pragma: no cover
+    except Exception:  # pragma: no cover
         print("An unexpected error occurred. See log for details.")
         logger.error("Unhandled exception in CLI")
         logger.error(traceback.format_exc())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-import importlib
 
 # Allow importing modules from the package directory when tests are run as a package
 package_path = Path(__file__).resolve().parents[1] / "cinder_web_scraper"

--- a/tests/test_content_extractor.py
+++ b/tests/test_content_extractor.py
@@ -1,4 +1,3 @@
-import pytest
 from cinder_web_scraper.scraping.content_extractor import ContentExtractor
 
 

--- a/tests/test_gui_components.py
+++ b/tests/test_gui_components.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from cinder_web_scraper.gui.main_window import MainWindow
 from cinder_web_scraper.gui.scheduler_dialog import SchedulerDialog
 from cinder_web_scraper.gui.settings_panel import SettingsPanel


### PR DESCRIPTION
## Summary
- clean up unused imports in scraping modules
- drop unused exception variable in entry points
- remove stray imports from tests

## Testing
- `bash setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713de9206c8332b2bb523824abdb8d