### PR TITLE
Ignore schedules DB and create file in setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 output/
 data/logs/
 *.db
+data/schedules.db

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,12 @@ mkdir -p data/logs output
 
 # Create empty config files if missing
 : > data/websites.json
-: > data/schedules.db
+if [ ! -f data/schedules.db ]; then
+  python - <<'EOF'
+from cinder_web_scraper.scheduling.schedule_manager import ScheduleManager
+ScheduleManager("data/schedules.db").close()
+EOF
+fi
 if [ ! -f data/config.json ]; then
   : > data/config.json
 fi


### PR DESCRIPTION
## Summary
- stop tracking `data/schedules.db`
- ignore the schedules database explicitly
- initialize the database from `setup.sh` when missing

## Testing
- `./setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713de68cec833284fd25e26b5bd708